### PR TITLE
Add API key environment variable support to GCP workflows

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -16,10 +16,14 @@ jobs:
 
       - name: Deploy to GCP Dev
         uses: appleboy/ssh-action@v1.0.0
+        env:
+          UPC_API_KEY: ${{ secrets.UPC_API_KEY }}
+          PEXELS_API_KEY: ${{ secrets.PEXELS_API_KEY }}
         with:
           host: ${{ secrets.GCP_DEV_HOST }}
           username: ${{ secrets.GCP_USERNAME }}
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          envs: UPC_API_KEY,PEXELS_API_KEY
           script: |
             set -e
 
@@ -29,6 +33,14 @@ jobs:
 
             # Navigate to app directory
             cd /home/$USER/freezer-inventory-dev
+
+            # Create .env file with API keys
+            echo "Creating .env file..."
+            cat > backend/.env << EOF
+            UPC_API_KEY=${UPC_API_KEY}
+            PEXELS_API_KEY=${PEXELS_API_KEY}
+            EOF
+            echo "✓ Environment variables configured"
 
             # Create backup before deployment
             echo "Creating backup..."

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -16,10 +16,14 @@ jobs:
 
       - name: Deploy to GCP Compute Engine
         uses: appleboy/ssh-action@v1.0.0
+        env:
+          UPC_API_KEY: ${{ secrets.UPC_API_KEY }}
+          PEXELS_API_KEY: ${{ secrets.PEXELS_API_KEY }}
         with:
           host: ${{ secrets.GCP_PROD_HOST }}
           username: ${{ secrets.GCP_USERNAME }}
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          envs: UPC_API_KEY,PEXELS_API_KEY
           script: |
             set -e
 
@@ -29,6 +33,14 @@ jobs:
 
             # Navigate to app directory
             cd /home/$USER/freezer-inventory
+
+            # Create .env file with API keys
+            echo "Creating .env file..."
+            cat > backend/.env << EOF
+            UPC_API_KEY=${UPC_API_KEY}
+            PEXELS_API_KEY=${PEXELS_API_KEY}
+            EOF
+            echo "✓ Environment variables configured"
 
             # Create backup before deployment
             echo "Creating backup..."

--- a/.github/workflows/restore-dev-gcp.yml
+++ b/.github/workflows/restore-dev-gcp.yml
@@ -70,10 +70,14 @@ jobs:
 
       - name: Restore dev environment
         uses: appleboy/ssh-action@v1.0.0
+        env:
+          UPC_API_KEY: ${{ secrets.UPC_API_KEY }}
+          PEXELS_API_KEY: ${{ secrets.PEXELS_API_KEY }}
         with:
           host: ${{ secrets.GCP_DEV_HOST }}
           username: ${{ secrets.GCP_USERNAME }}
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          envs: UPC_API_KEY,PEXELS_API_KEY
           script: |
             set -e
 
@@ -82,6 +86,14 @@ jobs:
             echo "======================================"
 
             cd /home/$USER/freezer-inventory-dev
+
+            # Create .env file with API keys
+            echo "Creating .env file..."
+            cat > backend/.env << EOF
+            UPC_API_KEY=${UPC_API_KEY}
+            PEXELS_API_KEY=${PEXELS_API_KEY}
+            EOF
+            echo "✓ Environment variables configured"
 
             # Pull latest code from main branch (prod code)
             echo "Syncing code with production (main branch)..."


### PR DESCRIPTION
- Configure UPC_API_KEY and PEXELS_API_KEY in all GCP deployment workflows
- Workflows now create .env files from GitHub Secrets during deployment
- Ensures API keys are available to backend without committing them to repo