### PR TITLE
Fix: Use absolute paths instead of $USER variable in GCP workflows

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -32,7 +32,7 @@ jobs:
             echo "======================================"
 
             # Navigate to app directory
-            cd /home/$USER/freezer-inventory-dev
+            cd /home/michaelt452/freezer-inventory-dev
 
             # Create .env file with API keys
             echo "Creating .env file..."
@@ -120,7 +120,7 @@ jobs:
             echo "✗ GCP Development Deployment Failed!"
             echo "======================================"
             echo "Rolling back to last backup..."
-            cd /home/$USER/freezer-inventory-dev
+            cd /home/michaelt452/freezer-inventory-dev
             LATEST_BACKUP=$(ls -t backups/freezer_inventory_*.db 2>/dev/null | head -1)
             if [ -n "$LATEST_BACKUP" ]; then
               cp "$LATEST_BACKUP" backend/instance/freezer_inventory.db

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -32,7 +32,7 @@ jobs:
             echo "======================================"
 
             # Navigate to app directory
-            cd /home/$USER/freezer-inventory
+            cd /home/michaelt452/freezer-inventory
 
             # Create .env file with API keys
             echo "Creating .env file..."
@@ -120,7 +120,7 @@ jobs:
             echo "✗ GCP Production Deployment Failed!"
             echo "======================================"
             echo "Rolling back to last backup..."
-            cd /home/$USER/freezer-inventory
+            cd /home/michaelt452/freezer-inventory
             LATEST_BACKUP=$(ls -t backups/freezer_inventory_*.db 2>/dev/null | head -1)
             if [ -n "$LATEST_BACKUP" ]; then
               cp "$LATEST_BACKUP" backend/instance/freezer_inventory.db

--- a/.github/workflows/restore-dev-gcp.yml
+++ b/.github/workflows/restore-dev-gcp.yml
@@ -31,7 +31,7 @@ jobs:
             echo "======================================"
             echo "Backing up current dev database..."
             echo "======================================"
-            cd /home/$USER/freezer-inventory-dev
+            cd /home/michaelt452/freezer-inventory-dev
             mkdir -p backups/pre-restore
             if [ -f backend/instance/freezer_inventory.db ]; then
               cp backend/instance/freezer_inventory.db backups/pre-restore/freezer_inventory_$(date +%Y%m%d_%H%M%S).db
@@ -50,9 +50,9 @@ jobs:
             echo "======================================"
 
             # Get the production database
-            if [ -f /home/$USER/freezer-inventory/backend/instance/freezer_inventory.db ]; then
+            if [ -f /home/michaelt452/freezer-inventory/backend/instance/freezer_inventory.db ]; then
               # Copy to a temp location accessible via SCP
-              cp /home/$USER/freezer-inventory/backend/instance/freezer_inventory.db /tmp/prod_freezer_inventory.db
+              cp /home/michaelt452/freezer-inventory/backend/instance/freezer_inventory.db /tmp/prod_freezer_inventory.db
               echo "✓ Production database copied to temp location"
             else
               echo "❌ Production database not found!"
@@ -85,7 +85,7 @@ jobs:
             echo "Restoring GCP Development Environment"
             echo "======================================"
 
-            cd /home/$USER/freezer-inventory-dev
+            cd /home/michaelt452/freezer-inventory-dev
 
             # Create .env file with API keys
             echo "Creating .env file..."
@@ -155,7 +155,7 @@ jobs:
             echo "  - Dependencies: Updated"
             echo ""
             echo "Note: Switch back to 'dev' branch when ready to resume dev work:"
-            echo "  cd /home/$USER/freezer-inventory-dev && git checkout dev"
+            echo "  cd /home/michaelt452/freezer-inventory-dev && git checkout dev"
 
       - name: Cleanup temp files
         if: always()


### PR DESCRIPTION
- Replace /home/$USER with /home/michaelt452 in all workflow files
- Fixes issue where gh-deploy user couldn't find deployment directories
- Affects prod, dev, and restore workflows