### PR TITLE
Fix deployment health check timing issue

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -80,7 +80,7 @@ jobs:
             echo "Restarting services..."
             sudo systemctl restart freezer-backend-dev
             sudo systemctl restart freezer-frontend-dev
-            sleep 5
+            sleep 15
             echo "✓ Services restarted"
 
             # Health check

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -80,7 +80,7 @@ jobs:
             echo "Restarting services..."
             sudo systemctl restart freezer-backend
             sudo systemctl restart freezer-frontend
-            sleep 5
+            sleep 15
             echo "✓ Services restarted"
 
             # Health check

--- a/.github/workflows/restore-dev-gcp.yml
+++ b/.github/workflows/restore-dev-gcp.yml
@@ -126,7 +126,7 @@ jobs:
             echo "Restarting services..."
             sudo systemctl restart freezer-backend-dev
             sudo systemctl restart freezer-frontend-dev
-            sleep 5
+            sleep 15
             echo "✓ Services restarted"
 
             # Health check


### PR DESCRIPTION
Increased service restart wait time from 5 to 15 seconds.

Issue: Frontend health checks were failing because Vite preview server needs ~10 seconds to start, but health check ran after only 5 seconds.

Solution: Wait 15 seconds after service restart to ensure both backend and frontend are fully ready before health checks.

Affects:
- deploy-dev-gcp.yml
- deploy-prod-gcp.yml
- restore-dev-gcp.yml