### PR TITLE
Fix React 19 compatibility - update @testing-library/react to v16

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "@vitejs/plugin-react": "^5.1.2",
     "esbuild": "^0.27.2",
     "vite": "^7.3.0",
-    "@testing-library/react": "^15.0.0",
+    "@testing-library/react": "^16.0.0",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/user-event": "^14.5.1",
     "@vitest/ui": "^4.0.16",


### PR DESCRIPTION
@testing-library/react v15.x still has React 18 peer dependency. Version 16.x has full React 19 stable support.

Fixes deployment error:
  peer react@"^18.0.0" from @testing-library/react@15.0.7