### PR TITLE
Security fix: Disable Flask debug mode in production

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -143,4 +143,9 @@ if __name__ == '__main__':
     print("  Password: admin123")
     print("  ⚠️  CHANGE THESE IN PRODUCTION!")
     print("="*50 + "\n")
-    app.run(debug=True, host='0.0.0.0', port=5001)
+
+    # SECURITY: Only enable debug mode in development
+    # Never run with debug=True in production as it enables the Werkzeug debugger
+    # which can be exploited for remote code execution
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() == 'true'
+    app.run(debug=debug_mode, host='0.0.0.0', port=5001)


### PR DESCRIPTION
Fixes CodeQL HIGH severity alert #7

Issue: Flask app.run(debug=True) enables Werkzeug debugger which allows arbitrary code execution in production.

Solution: Make debug mode conditional based on FLASK_DEBUG environment variable, defaulting to False for production safety.

Usage:
- Production (default): debug=False (secure)
- Development: Set FLASK_DEBUG=true in .env file

CWE-489: Active Debug Code