### PR TITLE
Security: Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - dev
 
+# SECURITY: Explicitly limit GITHUB_TOKEN permissions (principle of least privilege)
+# This workflow only needs to read repository contents for checkout
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy to GCP Development Server

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+# SECURITY: Explicitly limit GITHUB_TOKEN permissions (principle of least privilege)
+# This workflow only needs to read repository contents for checkout
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy to GCP Production Server

--- a/.github/workflows/restore-dev-gcp.yml
+++ b/.github/workflows/restore-dev-gcp.yml
@@ -8,6 +8,10 @@ on:
         required: true
         default: ''
 
+# SECURITY: Explicitly limit GITHUB_TOKEN permissions (principle of least privilege)
+# This workflow doesn't interact with GitHub resources, so no permissions needed
+permissions: {}
+
 jobs:
   restore:
     name: Restore GCP Development from Production


### PR DESCRIPTION
Fixes CodeQL workflow permission alerts by adding explicit GITHUB_TOKEN permissions to all GCP deployment workflows.

**Root Cause:**
GitHub Actions workflows without explicit permissions blocks grant GITHUB_TOKEN all permissions by default. This violates the principle of least privilege and creates unnecessary security risk.

**Changes:**

1. deploy-prod-gcp.yml:
   - Added: permissions: { contents: read }
   - Justification: Only needs to read repo contents for checkout

2. deploy-dev-gcp.yml:
   - Added: permissions: { contents: read }
   - Justification: Only needs to read repo contents for checkout

3. restore-dev-gcp.yml:
   - Added: permissions: {}
   - Justification: No GitHub resources accessed (SSH only)

**Security Improvements:**
- ✅ Follows principle of least privilege
- ✅ Limits GITHUB_TOKEN to only required permissions
- ✅ Reduces attack surface if workflow is compromised
- ✅ Makes permissions explicit and auditable
- ✅ Aligns with GitHub security best practices

**Permissions Rationale:**
- contents:read - Minimal permission for actions/checkout
- {} (empty) - No permissions when workflow only uses SSH

**Testing:**
- YAML syntax validation: ✓ Passed
- No functional changes to deployment logic
- Workflows will continue to work identically

**References:**
- GitHub Security Hardening Guide
- OWASP Principle of Least Privilege