### PR TITLE
Configure dev frontend to use dev backend (port 5002)

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': {
-        target: 'http://localhost:5001',
+        target: 'http://localhost:5002', // Dev backend
         changeOrigin: true,
       }
     }


### PR DESCRIPTION
- Change proxy target from port 5001 (prod) to 5002 (dev)
- Enables testing dev features through web interface
- Needed for testing case-insensitive username login