### PR TITLE
Separate dev and prod databases (Issue #55)

### DIFF
--- a/DB_SEPARATION_GUIDE.md
+++ b/DB_SEPARATION_GUIDE.md
@@ -1,0 +1,130 @@
+# Database Separation Guide (Issue #55)
+
+## Problem
+Dev and production backends are currently sharing the same database file, which means:
+- Changes in dev affect production data ❌
+- Can't safely test destructive operations ❌
+- No isolation between environments ❌
+
+## Solution
+Separate databases using environment variables:
+- **Production**: `instance/freezer_inventory.db`
+- **Dev**: `instance/freezer_inventory_dev.db`
+
+## Implementation Steps
+
+### Step 1: Update Systemd Services
+
+#### Production Backend Service
+```bash
+sudo nano /etc/systemd/system/freezer-backend.service
+```
+
+Add this line in the `[Service]` section:
+```ini
+Environment="DATABASE_PATH=freezer_inventory.db"
+```
+
+#### Dev Backend Service
+```bash
+sudo nano /etc/systemd/system/freezer-backend-dev.service
+```
+
+Add this line in the `[Service]` section:
+```ini
+Environment="DATABASE_PATH=freezer_inventory_dev.db"
+```
+
+### Step 2: Reload Systemd and Restart Services
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart freezer-backend
+sudo systemctl restart freezer-backend-dev
+```
+
+### Step 3: Verify Separation
+Check that each service is using the correct database:
+
+```bash
+# Check production backend logs
+sudo journalctl -u freezer-backend --since "1 minute ago" | grep "Database will be created at"
+
+# Check dev backend logs
+sudo journalctl -u freezer-backend-dev --since "1 minute ago" | grep "Database will be created at"
+```
+
+You should see:
+- **Production**: `/home/michaelt452/freezer-inventory/backend/instance/freezer_inventory.db`
+- **Dev**: `/home/michaelt452/freezer-inventory/backend/instance/freezer_inventory_dev.db`
+
+### Step 4: Sync Production Data to Dev
+
+After separation, the dev database will be empty. Sync production data to dev:
+
+```bash
+cd /home/michaelt452/freezer-inventory/backend
+./sync_prod_to_dev_db.sh
+```
+
+This will:
+- ✅ Backup existing dev database (if any)
+- ✅ Copy production database to dev
+- ✅ Show database statistics
+- ✅ Preserve production database (read-only copy)
+
+### Step 5: Test Separation
+
+Test that changes in dev don't affect production:
+
+```bash
+# Add a test item in dev (port 5002)
+curl -X POST http://localhost:5002/api/items \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <dev_token>" \
+  -d '{
+    "name": "TEST ITEM - DEV ONLY",
+    "category_id": 1,
+    "quantity": 999,
+    "location": "DEV TEST"
+  }'
+
+# Check production (port 5001) - should NOT have this item
+curl http://localhost:5001/api/items \
+  -H "Authorization: Bearer <prod_token>"
+```
+
+If the test item only appears in dev, databases are properly separated! ✅
+
+## Ongoing Maintenance
+
+### Regular Sync from Prod to Dev
+Run this whenever you want fresh production data in dev:
+
+```bash
+cd /home/michaelt452/freezer-inventory/backend
+./sync_prod_to_dev_db.sh
+sudo systemctl restart freezer-backend-dev
+```
+
+**Note**: This overwrites dev database, so any dev-only test data will be lost.
+
+### Backup Strategy
+- Dev database backups are automatically created before each sync
+- Backups are stored in: `backend/instance/backups/`
+- Consider setting up automated daily backups of production DB
+
+## Environment Variables Summary
+
+| Variable | Production | Dev |
+|----------|-----------|-----|
+| `DATABASE_PATH` | `freezer_inventory.db` | `freezer_inventory_dev.db` |
+| Port | 5001 | 5002 |
+| Service | `freezer-backend` | `freezer-backend-dev` |
+
+## Rollback Plan
+
+If something goes wrong, you can revert by:
+
+1. Remove the `Environment=` lines from systemd services
+2. Reload and restart: `sudo systemctl daemon-reload && sudo systemctl restart freezer-backend freezer-backend-dev`
+3. Both will use the default `freezer_inventory.db` (pre-separation behavior)

--- a/backend/app.py
+++ b/backend/app.py
@@ -16,7 +16,11 @@ def create_app(test_config=None):
         # Production configuration
         # Use absolute path for database to ensure it's always in the backend directory
         basedir = os.path.abspath(os.path.dirname(__file__))
-        db_path = os.path.join(basedir, 'instance', 'freezer_inventory.db')
+
+        # Allow environment-specific database paths
+        # Use DATABASE_PATH env var if set, otherwise default to freezer_inventory.db
+        db_filename = os.environ.get('DATABASE_PATH', 'freezer_inventory.db')
+        db_path = os.path.join(basedir, 'instance', db_filename)
         app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
         app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
         app.config['JWT_SECRET_KEY'] = os.environ.get('JWT_SECRET_KEY', 'dev-secret-key-change-in-production')

--- a/backend/sync_prod_to_dev_db.sh
+++ b/backend/sync_prod_to_dev_db.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Sync production database to dev database
+# This creates a fresh copy of production data for safe testing in dev
+
+set -e  # Exit on error
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTANCE_DIR="$SCRIPT_DIR/instance"
+
+PROD_DB="$INSTANCE_DIR/freezer_inventory.db"
+DEV_DB="$INSTANCE_DIR/freezer_inventory_dev.db"
+BACKUP_DIR="$INSTANCE_DIR/backups"
+
+echo "=========================================="
+echo "Database Sync: Production → Dev"
+echo "=========================================="
+echo ""
+
+# Create instance and backup directories if they don't exist
+mkdir -p "$INSTANCE_DIR"
+mkdir -p "$BACKUP_DIR"
+
+# Check if production database exists
+if [ ! -f "$PROD_DB" ]; then
+    echo "❌ Error: Production database not found at: $PROD_DB"
+    echo "   Please ensure the production backend has been initialized."
+    exit 1
+fi
+
+echo "Production DB: $PROD_DB"
+echo "Dev DB:        $DEV_DB"
+echo ""
+
+# Backup existing dev database if it exists
+if [ -f "$DEV_DB" ]; then
+    TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+    BACKUP_FILE="$BACKUP_DIR/freezer_inventory_dev_backup_$TIMESTAMP.db"
+    echo "📦 Backing up existing dev database..."
+    cp "$DEV_DB" "$BACKUP_FILE"
+    echo "   Backup saved to: $BACKUP_FILE"
+    echo ""
+fi
+
+# Copy production database to dev
+echo "🔄 Copying production database to dev..."
+cp "$PROD_DB" "$DEV_DB"
+
+# Get database stats
+PROD_SIZE=$(du -h "$PROD_DB" | cut -f1)
+DEV_SIZE=$(du -h "$DEV_DB" | cut -f1)
+
+echo "✅ Sync complete!"
+echo ""
+echo "Database sizes:"
+echo "  Production: $PROD_SIZE"
+echo "  Dev:        $DEV_SIZE"
+echo ""
+
+# Count records in dev database
+echo "Dev database contents:"
+sqlite3 "$DEV_DB" << 'EOF'
+.mode column
+.headers on
+SELECT
+    'Users' as table_name,
+    COUNT(*) as record_count
+FROM users
+UNION ALL
+SELECT
+    'Categories',
+    COUNT(*)
+FROM categories
+UNION ALL
+SELECT
+    'Items',
+    COUNT(*)
+FROM items;
+EOF
+
+echo ""
+echo "=========================================="
+echo "✅ Dev database is now a copy of production"
+echo "   You can safely test in dev without affecting prod"
+echo "=========================================="


### PR DESCRIPTION
- Make database path configurable via DATABASE_PATH env var
- Create sync script to copy prod DB → dev DB with backups
- Add comprehensive deployment guide
- Enables safe testing without affecting production data

Changes:
- backend/app.py: Use DATABASE_PATH env var for db filename
- backend/sync_prod_to_dev_db.sh: Sync script with automatic backups
- DB_SEPARATION_GUIDE.md: Step-by-step setup instructions