### PR TITLE
Fix expiration date calculation to use midnight

### DIFF
--- a/frontend/src/components/AddItemModal.jsx
+++ b/frontend/src/components/AddItemModal.jsx
@@ -81,6 +81,7 @@ function AddItemModal({ item, categories, onClose, onSave, onCategoryCreated }) 
       const category = categories.find((c) => c.id === parseInt(categoryId));
       if (category && category.default_expiration_days) {
         const expirationDate = new Date();
+        expirationDate.setHours(0, 0, 0, 0); // Reset to midnight for consistent day counting
         expirationDate.setDate(expirationDate.getDate() + category.default_expiration_days);
         setFormData((prev) => ({
           ...prev,
@@ -185,6 +186,7 @@ function AddItemModal({ item, categories, onClose, onSave, onCategoryCreated }) 
       // Auto-calculate expiration date based on new category's default
       if (createdCategory.default_expiration_days && !formData.expiration_date) {
         const expirationDate = new Date();
+        expirationDate.setHours(0, 0, 0, 0); // Reset to midnight for consistent day counting
         expirationDate.setDate(expirationDate.getDate() + createdCategory.default_expiration_days);
         setFormData((prev) => ({
           ...prev,


### PR DESCRIPTION
- Reset time to midnight before adding days
- Prevents off-by-one errors (365 days showing as 366)
- Ensures consistent day counting with daysBetween function