### PR TITLE
Fix dev frontend to proxy to dev backend (port 5002)

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,15 +1,22 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    host: '0.0.0.0', // Explicitly bind to all network interfaces
-    port: 3000,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:5001', // Production backend
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  // Determine backend port based on environment
+  // In development mode, use dev backend (5002)
+  // In production/preview mode, use production backend (5001)
+  const backendPort = mode === 'development' ? 5002 : 5001;
+
+  return {
+    plugins: [react()],
+    server: {
+      host: '0.0.0.0', // Explicitly bind to all network interfaces
+      port: 3000,
+      proxy: {
+        '/api': {
+          target: `http://localhost:${backendPort}`,
+          changeOrigin: true,
+        }
       }
     }
   }


### PR DESCRIPTION
The Vite proxy was hardcoded to port 5001 (production backend), causing dev-only endpoints like /items/purge-all to return 404 when accessed from the dev frontend.

Now the proxy dynamically selects the backend port based on Vite's mode:
- development mode: proxies to port 5002 (dev backend)
- production/preview mode: proxies to port 5001 (production backend)

This ensures the dev frontend (running on port 3001) properly communicates with the dev backend that has FLASK_ENV=development set.