### PR TITLE
Fix deployment: clean Vite cache before npm ci

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -72,6 +72,8 @@ jobs:
             # Update frontend dependencies
             echo "Updating frontend dependencies..."
             cd frontend
+            # Clean Vite cache to avoid permission issues
+            rm -rf node_modules/.vite 2>/dev/null || true
             npm ci --quiet
             echo "✓ Frontend dependencies updated"
 


### PR DESCRIPTION
Vite cache files created by the running dev server cause EACCES errors during deployment when npm ci tries to delete them. Clean the cache directory before running npm ci to avoid permission conflicts.