### PR TITLE
Stop services before updating dependencies

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -61,6 +61,12 @@ jobs:
             git reset --hard origin/dev
             echo "✓ Code updated"
 
+            # Stop services before updating dependencies
+            echo "Stopping services..."
+            sudo systemctl stop freezer-backend-dev
+            sudo systemctl stop freezer-frontend-dev
+            echo "✓ Services stopped"
+
             # Update backend dependencies
             echo "Updating backend dependencies..."
             cd backend
@@ -72,7 +78,7 @@ jobs:
             # Update frontend dependencies
             echo "Updating frontend dependencies..."
             cd frontend
-            # Clean Vite cache to avoid permission issues
+            # Clean Vite cache (now safe since service is stopped)
             rm -rf node_modules/.vite 2>/dev/null || true
             npm ci --quiet
             echo "✓ Frontend dependencies updated"


### PR DESCRIPTION
Prevent EACCES errors by stopping dev services before cleaning cache and updating dependencies. Services are restarted after deployment.