### PR TITLE
Fix dev deployment: remove entire node_modules for clean install

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -78,8 +78,8 @@ jobs:
             # Update frontend dependencies
             echo "Updating frontend dependencies..."
             cd frontend
-            # Clean Vite cache with sudo (cache files may be owned by different user)
-            sudo rm -rf node_modules/.vite 2>/dev/null || true
+            # Remove node_modules completely for clean install (avoids permission issues)
+            sudo rm -rf node_modules 2>/dev/null || true
             npm ci --quiet
             echo "✓ Frontend dependencies updated"
 


### PR DESCRIPTION
Fixes the persistent EACCES permission errors during dev deployments.

## Changes:
- Updated deployment workflow to remove entire `node_modules` directory instead of just `.vite` cache
- This ensures a completely clean npm install on each deployment
- Requires updated sudoers rule on dev server (already configured)

## Testing:
- Tested manually on dev server - works correctly
- Deployment should now succeed without permission errors

## Notes:
This completes the deployment fixes needed for the dev environment. After this merges, dev deployments should be stable and reliable.
