### PR TITLE
Run npm ci with sudo to avoid permission issues

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -80,7 +80,7 @@ jobs:
             cd frontend
             # Remove node_modules completely for clean install (avoids permission issues)
             sudo rm -rf node_modules 2>/dev/null || true
-            npm ci --quiet
+            sudo npm ci --quiet
             echo "✓ Frontend dependencies updated"
 
             # Build frontend


### PR DESCRIPTION
npm ci needs sudo to properly clean up its cache directories during installation.

## Changes:
- Run `sudo npm ci` instead of just `npm ci` in deployment workflow
- Prevents EACCES errors on .vite/deps during npm install

## Setup Required:
Added `gh-deploy ALL=(ALL) NOPASSWD: /usr/bin/npm` to sudoers (already done on server)

This should finally resolve the persistent deployment permission errors.
