### PR TITLE
Fix QR code scanning - use full URLs (#84)

### DIFF
--- a/backend/routes/items.py
+++ b/backend/routes/items.py
@@ -18,6 +18,20 @@ from reportlab.lib.utils import ImageReader
 items_bp = Blueprint('items', __name__)
 
 
+def get_base_url():
+    """Get the base URL for the application based on environment.
+
+    Returns the appropriate domain for QR codes and links.
+    """
+    # Check if we're in development mode
+    is_dev = os.environ.get('FLASK_ENV') == 'development'
+
+    if is_dev:
+        return 'https://dev.thefreezer.xyz'
+    else:
+        return 'https://thefreezer.xyz'
+
+
 def get_category_stock_image(category_name):
     """Get a stock image URL for a given category.
 
@@ -503,8 +517,9 @@ def get_qr_image(qr_code):
         border=4,
     )
 
-    # Encode the QR code with the freezer item URL
-    qr_data = f"freezer-item:{qr_code}"
+    # Encode the QR code with a full URL that phones can open
+    base_url = get_base_url()
+    qr_data = f"{base_url}/item/{qr_code}"
     qr.add_data(qr_data)
     qr.make(fit=True)
 
@@ -802,7 +817,9 @@ def print_labels():
             box_size=10,
             border=2,
         )
-        qr_data = f"freezer-item:{item.qr_code}"
+        # Encode with full URL that phones can open
+        base_url = get_base_url()
+        qr_data = f"{base_url}/item/{item.qr_code}"
         qr.add_data(qr_data)
         qr.make(fit=True)
         img = qr.make_image(fill_color="black", back_color="white")

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import Inventory from './pages/Inventory';
 import Categories from './pages/Categories';
 import PrintLabels from './pages/PrintLabels';
 import Settings from './pages/Settings';
+import QRRedirect from './pages/QRRedirect';
 
 function App() {
   const [user, setUser] = useState(null);
@@ -80,6 +81,7 @@ function App() {
 
           <Routes>
             <Route path="/" element={<Inventory />} />
+            <Route path="/item/:qrCode" element={<QRRedirect />} />
             <Route path="/categories" element={<Categories />} />
             <Route path="/print-labels" element={<PrintLabels />} />
             <Route path="/settings" element={<Settings user={user} />} />

--- a/frontend/src/pages/Inventory.jsx
+++ b/frontend/src/pages/Inventory.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { itemsAPI, categoriesAPI } from '../services/api';
 import ItemCard from '../components/ItemCard';
 import AddItemModal from '../components/AddItemModal';
@@ -11,6 +12,7 @@ function Inventory() {
   const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [searchParams, setSearchParams] = useSearchParams();
 
   // Detect if running in development mode
   const isDev = import.meta.env.DEV;
@@ -30,6 +32,17 @@ function Inventory() {
 
   // Session tracking - force re-render when session changes
   const [sessionKey, setSessionKey] = useState(0);
+
+  // Handle QR code from URL parameter (when scanned)
+  useEffect(() => {
+    const qrCode = searchParams.get('qr');
+    if (qrCode) {
+      setSearch(qrCode);
+      setStatusFilter('all'); // Search across all statuses
+      // Clear the QR parameter from URL
+      setSearchParams({});
+    }
+  }, [searchParams, setSearchParams]);
 
   useEffect(() => {
     loadCategories();

--- a/frontend/src/pages/QRRedirect.jsx
+++ b/frontend/src/pages/QRRedirect.jsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+
+/**
+ * QRRedirect - Handles QR code scans and redirects to inventory
+ *
+ * When a QR code is scanned, this component:
+ * 1. Extracts the QR code from the URL
+ * 2. Redirects to inventory with the QR code as a search parameter
+ * 3. The Inventory page will auto-search and show the item
+ */
+function QRRedirect() {
+  const { qrCode } = useParams();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (qrCode) {
+      // Redirect to inventory with the QR code as search parameter
+      navigate(`/?qr=${qrCode}`);
+    } else {
+      // No QR code provided, just go to inventory
+      navigate('/');
+    }
+  }, [qrCode, navigate]);
+
+  return (
+    <div className="container" style={{ textAlign: 'center', marginTop: '2rem' }}>
+      <h2>Loading item...</h2>
+      <p>Redirecting to inventory...</p>
+    </div>
+  );
+}
+
+export default QRRedirect;


### PR DESCRIPTION
Fixes #84 - QR codes now scannable on phones

## Problem
QR codes used custom scheme `freezer-item:ABC123` which phones couldn't recognize

## Solution
QR codes now encode full URLs that phones can open:
- Production: `https://thefreezer.xyz/item/{qr_code}`
- Dev: `https://dev.thefreezer.xyz/item/{qr_code}`

## Changes
- Backend: Environment-aware URL generation
- Frontend: QR redirect route and auto-search
- Works on iOS and Android

## Testing
1. Print a label
2. Scan QR code with phone
3. Should open browser to item page
4. Item auto-searches in inventory
