### PR TITLE
Fix QR code scan to trigger item lookup instead of search

### DIFF
--- a/frontend/src/pages/Inventory.jsx
+++ b/frontend/src/pages/Inventory.jsx
@@ -37,11 +37,12 @@ function Inventory() {
   useEffect(() => {
     const qrCode = searchParams.get('qr');
     if (qrCode) {
-      setSearch(qrCode);
-      setStatusFilter('all'); // Search across all statuses
-      // Clear the QR parameter from URL
+      // Clear the QR parameter from URL immediately
       setSearchParams({});
+      // Look up the item by QR code (same as "Locate Item by Code" button)
+      handleQRSubmit(qrCode);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams, setSearchParams]);
 
   useEffect(() => {


### PR DESCRIPTION
When scanning a QR code, now calls handleQRSubmit() to look up the item by QR code (same as 'Locate Item by Code' button), instead of just putting the code in the search field which doesn't search by QR code.