### PR TITLE
Make QR scanner guide box a large square

### DIFF
--- a/frontend/src/components/QRScanner.jsx
+++ b/frontend/src/components/QRScanner.jsx
@@ -210,16 +210,16 @@ function QRScanner({ onScan, onClose }) {
         style={{ display: 'none' }}
       />
 
-      {/* Scanning guide overlay */}
+      {/* Scanning guide overlay - large square for QR codes */}
       {scanning && !item && !loading && (
         <div style={{
           position: 'absolute',
           top: '50%',
           left: '50%',
           transform: 'translate(-50%, -50%)',
-          width: '85%',
-          maxWidth: '400px',
-          height: '180px',
+          width: '75%',
+          maxWidth: '350px',
+          aspectRatio: '1 / 1',
           border: '3px solid #4caf50',
           borderRadius: '12px',
           pointerEvents: 'none',


### PR DESCRIPTION
Changed QR scanner alignment box from rectangle to square for better QR code scanning experience.

Changes:
- Width: 75% (max 350px) - slightly smaller than before for balance
- Height: uses aspectRatio: 1/1 to create perfect square
- This matches QR code shape better than rectangular guide

The square shape makes it much easier to align QR codes properly since QR codes are square by design.