### PR TITLE
Fix quick action buttons - match color scheme and data formatting

### DIFF
--- a/frontend/src/components/AddItemModal.jsx
+++ b/frontend/src/components/AddItemModal.jsx
@@ -363,11 +363,16 @@ function AddItemModal({ item, categories, onClose, onSave, onCategoryCreated }) 
       setLoading(true);
       setError('');
 
-      await itemsAPI.updateItem(item.id, {
+      const submitData = {
         ...formData,
+        weight: formData.weight ? parseFloat(formData.weight) : null,
+        category_id: formData.category_id ? parseInt(formData.category_id) : null,
+        upc: formData.upc && formData.upc.trim() ? formData.upc.trim() : null,
         status: 'consumed',
         removed_date: new Date().toISOString().split('T')[0]
-      });
+      };
+
+      await itemsAPI.updateItem(item.id, submitData);
 
       onSave();
     } catch (err) {
@@ -384,11 +389,16 @@ function AddItemModal({ item, categories, onClose, onSave, onCategoryCreated }) 
       setLoading(true);
       setError('');
 
-      await itemsAPI.updateItem(item.id, {
+      const submitData = {
         ...formData,
+        weight: formData.weight ? parseFloat(formData.weight) : null,
+        category_id: formData.category_id ? parseInt(formData.category_id) : null,
+        upc: formData.upc && formData.upc.trim() ? formData.upc.trim() : null,
         status: 'thrown_out',
         removed_date: new Date().toISOString().split('T')[0]
-      });
+      };
+
+      await itemsAPI.updateItem(item.id, submitData);
 
       onSave();
     } catch (err) {
@@ -744,7 +754,7 @@ function AddItemModal({ item, categories, onClose, onSave, onCategoryCreated }) 
                 onClick={handleMarkAsThrownOut}
                 disabled={loading}
                 style={{
-                  backgroundColor: '#ff9800',
+                  backgroundColor: '#f44336',
                   color: 'white',
                   border: 'none'
                 }}


### PR DESCRIPTION
Fixed two issues with the Mark as Consumed/Thrown Out buttons:

1. Color scheme fix:
   - Changed 'Mark as Thrown Out' button from orange (#ff9800) to red (#f44336)
   - Now matches the main inventory screen color scheme

2. Functionality fix:
   - Added proper data formatting in handleMarkAsConsumed and handleMarkAsThrownOut
   - Parse weight as float (was being sent as string)
   - Parse category_id as int (was being sent as string)
   - Trim and handle UPC properly (nullable)
   - This matches the formatting in handleSubmit and ensures the API receives properly typed data

The buttons now work correctly and match the visual design.