### PR TITLE
Fix quick action buttons on QR scan modal and auto-close scanner

### DIFF
--- a/backend/routes/items.py
+++ b/backend/routes/items.py
@@ -354,6 +354,13 @@ def update_item(item_id):
         item.expiration_date = datetime.fromisoformat(data['expiration_date']) if data['expiration_date'] else None
     if 'notes' in data:
         item.notes = data['notes']
+    if 'status' in data:
+        # Validate status
+        if data['status'] not in ['in_freezer', 'consumed', 'thrown_out']:
+            return jsonify({'error': 'Invalid status'}), 400
+        item.status = data['status']
+    if 'removed_date' in data:
+        item.removed_date = datetime.fromisoformat(data['removed_date']) if data['removed_date'] else None
 
     db.session.commit()
 

--- a/frontend/src/components/AddItemModal.jsx
+++ b/frontend/src/components/AddItemModal.jsx
@@ -357,7 +357,14 @@ function AddItemModal({ item, categories, onClose, onSave, onCategoryCreated }) 
   };
 
   const handleMarkAsConsumed = async () => {
-    if (!item || !item.id) return;
+    console.log('handleMarkAsConsumed called');
+    console.log('item:', item);
+    console.log('formData:', formData);
+
+    if (!item || !item.id) {
+      console.log('Early return: no item or item.id');
+      return;
+    }
 
     try {
       setLoading(true);
@@ -372,10 +379,15 @@ function AddItemModal({ item, categories, onClose, onSave, onCategoryCreated }) 
         removed_date: new Date().toISOString().split('T')[0]
       };
 
+      console.log('submitData:', submitData);
+      console.log('Calling API updateItem with id:', item.id);
+
       await itemsAPI.updateItem(item.id, submitData);
 
+      console.log('API call succeeded, calling onSave()');
       onSave();
     } catch (err) {
+      console.error('Error in handleMarkAsConsumed:', err);
       setError(err.response?.data?.error || 'Failed to mark item as consumed.');
     } finally {
       setLoading(false);
@@ -383,7 +395,14 @@ function AddItemModal({ item, categories, onClose, onSave, onCategoryCreated }) 
   };
 
   const handleMarkAsThrownOut = async () => {
-    if (!item || !item.id) return;
+    console.log('handleMarkAsThrownOut called');
+    console.log('item:', item);
+    console.log('formData:', formData);
+
+    if (!item || !item.id) {
+      console.log('Early return: no item or item.id');
+      return;
+    }
 
     try {
       setLoading(true);
@@ -398,10 +417,15 @@ function AddItemModal({ item, categories, onClose, onSave, onCategoryCreated }) 
         removed_date: new Date().toISOString().split('T')[0]
       };
 
+      console.log('submitData:', submitData);
+      console.log('Calling API updateItem with id:', item.id);
+
       await itemsAPI.updateItem(item.id, submitData);
 
+      console.log('API call succeeded, calling onSave()');
       onSave();
     } catch (err) {
+      console.error('Error in handleMarkAsThrownOut:', err);
       setError(err.response?.data?.error || 'Failed to mark item as thrown out.');
     } finally {
       setLoading(false);

--- a/frontend/src/components/QRScanner.jsx
+++ b/frontend/src/components/QRScanner.jsx
@@ -130,6 +130,12 @@ function QRScanner({ onScan, onClose }) {
       if (onScan) {
         onScan(response.data);
       }
+
+      // Close the scanner after successfully passing the item to parent
+      // Give a brief moment to show the success message, then close
+      setTimeout(() => {
+        onClose();
+      }, 500);
     } catch (err) {
       setError(`Item not found: ${qrCode}`);
       // Restart scanning after a brief delay to allow user to read error


### PR DESCRIPTION
Backend:
- Add status and removed_date field support to update_item endpoint
- These fields were missing, causing quick action buttons to not work

Frontend:
- Auto-close QR scanner after successful scan (was staying open and blocking modal)
- Add debugging console.log statements to quick action handlers