### PR TITLE
Fix navbar logo size for desktop and reduce mobile landing spacing

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -872,6 +872,15 @@ body {
   vertical-align: middle;
 }
 
+/* Larger logo on desktop */
+@media (min-width: 769px) {
+  .navbar-logo {
+    width: 30px;
+    height: 30px;
+    border-radius: 5px;
+  }
+}
+
 /* Mobile Navbar Adjustments */
 .navbar-mobile {
   position: sticky;

--- a/frontend/src/pages/MobileLanding.css
+++ b/frontend/src/pages/MobileLanding.css
@@ -9,7 +9,7 @@
 
 .mobile-landing-header {
   text-align: center;
-  padding: 20px 20px 10px;
+  padding: 20px 20px 5px;
   color: #2c3e50;
 }
 
@@ -17,7 +17,7 @@
   width: 100px;
   height: 100px;
   border-radius: 20px;
-  margin: 0 auto 20px;
+  margin: 0 auto 15px;
   display: block;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
@@ -25,7 +25,7 @@
 .mobile-landing-title {
   font-size: 28px;
   font-weight: 700;
-  margin: 0 0 8px;
+  margin: 0;
   color: #2c3e50;
 }
 


### PR DESCRIPTION
- Desktop: Increase logo from 24px to 30px (25% larger)
- Mobile: Keep logo at 24px
- Further reduce mobile landing page spacing:
  - Header bottom padding: 10px → 5px
  - Logo bottom margin: 20px → 15px
  - Title margin: 0 0 8px → 0
- Eliminates remaining buffer between title and buttons