### PR TITLE
Fix desktop interface toggle visibility and eliminate mobile landing buffer

### DIFF
--- a/frontend/src/pages/MobileLanding.css
+++ b/frontend/src/pages/MobileLanding.css
@@ -2,30 +2,30 @@
 .mobile-landing {
   min-height: 100vh;
   background: #f5f5f5;
-  padding: 20px;
+  padding: 15px;
   display: flex;
   flex-direction: column;
 }
 
 .mobile-landing-header {
   text-align: center;
-  padding: 15px 20px 0;
+  padding: 10px 15px 0;
   color: #2c3e50;
 }
 
 .mobile-landing-logo {
-  width: 100px;
-  height: 100px;
-  border-radius: 20px;
-  margin: 0 auto 10px;
+  width: 80px;
+  height: 80px;
+  border-radius: 16px;
+  margin: 0 auto 8px;
   display: block;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
 }
 
 .mobile-landing-title {
-  font-size: 28px;
+  font-size: 24px;
   font-weight: 700;
-  margin: 0 0 0 0;
+  margin: 0;
   color: #2c3e50;
 }
 
@@ -36,12 +36,10 @@
 }
 
 .mobile-landing-actions {
-  flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 5px 0;
-  justify-content: center;
+  gap: 12px;
+  padding: 12px 0 0 0;
 }
 
 .mobile-landing-button {

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -3,6 +3,7 @@ import { settingsAPI, authAPI } from '../services/api';
 import UserManagement from '../components/UserManagement';
 import ImportExport from '../components/ImportExport';
 import api from '../services/api';
+import { isMobileDevice } from '../utils/deviceDetection';
 
 function Settings({ user, isMobile = false, setUseDesktopInterface }) {
   const [settings, setSettings] = useState({
@@ -325,7 +326,7 @@ function Settings({ user, isMobile = false, setUseDesktopInterface }) {
           </small>
         </div>
 
-        {isMobile && (
+        {isMobileDevice() && (
           <div className="form-group" style={{ marginTop: '1.5rem' }}>
             <label style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}>
               <input


### PR DESCRIPTION
Settings toggle fix:
- Use isMobileDevice() instead of isMobile prop
- Toggle now shows on mobile devices even when using desktop interface
- Allows users to easily switch back to mobile interface

Mobile landing spacing fix:
- REMOVED justify-content: center (main culprit for buffer)
- REMOVED flex: 1 from actions container
- Reduced page padding: 20px → 15px
- Reduced header padding: 15px 20px 0 → 10px 15px 0
- Reduced logo size: 100px → 80px (more compact)
- Reduced logo margin: 10px → 8px
- Reduced title font: 28px → 24px
- Reduced actions gap: 16px → 12px
- Changed actions padding: 5px 0 → 12px 0 0 0

This eliminates the buffer and prevents scrolling on landing page