### PR TITLE
Implement activation code workflow and update run-tests.sh

### DIFF
--- a/backend/migrations/debug_passkey_name.sql
+++ b/backend/migrations/debug_passkey_name.sql
@@ -1,0 +1,23 @@
+-- Debug script to check passkey_credentials schema and data
+-- Run with: sqlite3 ~/freezer-inventory-dev/instance/freezer_inventory_dev.db < debug_passkey_name.sql
+
+.mode column
+.headers on
+
+-- Check table schema
+SELECT '=== TABLE SCHEMA ===' as Info;
+PRAGMA table_info(passkey_credentials);
+
+-- Check existing passkey data
+SELECT '=== EXISTING PASSKEYS ===' as Info;
+SELECT id, user_id, name, created_at FROM passkey_credentials ORDER BY created_at DESC LIMIT 10;
+
+-- Check if name column exists and has data
+SELECT '=== NAME COLUMN CHECK ===' as Info;
+SELECT
+    CASE
+        WHEN COUNT(*) > 0 THEN 'Name column EXISTS'
+        ELSE 'Name column MISSING'
+    END as Status
+FROM pragma_table_info('passkey_credentials')
+WHERE name = 'name';

--- a/frontend/src/components/UserManagement.jsx
+++ b/frontend/src/components/UserManagement.jsx
@@ -9,11 +9,12 @@ function UserManagement({ currentUser }) {
   const [showAddModal, setShowAddModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [showResetPasswordModal, setShowResetPasswordModal] = useState(false);
+  const [showActivationCodeModal, setShowActivationCodeModal] = useState(false);
   const [selectedUser, setSelectedUser] = useState(null);
+  const [activationCode, setActivationCode] = useState('');
 
   const [newUser, setNewUser] = useState({
     username: '',
-    password: '',
     role: 'user',
   });
 
@@ -50,16 +51,12 @@ function UserManagement({ currentUser }) {
     setError('');
     setSuccess('');
 
-    if (newUser.password.length < 6) {
-      setError('Password must be at least 6 characters');
-      return;
-    }
-
     try {
-      await authAPI.register(newUser.username, newUser.password, newUser.role);
-      setSuccess('User created successfully');
+      const response = await authAPI.register(newUser.username, null, newUser.role);
+      setActivationCode(response.data.activation_code);
       setShowAddModal(false);
-      setNewUser({ username: '', password: '', role: 'user' });
+      setShowActivationCodeModal(true);
+      setNewUser({ username: '', role: 'user' });
       loadUsers();
     } catch (err) {
       setError(err.response?.data?.error || 'Failed to create user');
@@ -243,6 +240,10 @@ function UserManagement({ currentUser }) {
             </div>
             <form onSubmit={handleAddUser}>
               <div className="modal-body">
+                <p style={{ color: '#7f8c8d', fontSize: '0.9rem', marginBottom: '1rem' }}>
+                  A one-time activation code will be generated for the user to set up their passkey.
+                </p>
+
                 <div className="form-group">
                   <label htmlFor="new-username">Username</label>
                   <input
@@ -252,21 +253,6 @@ function UserManagement({ currentUser }) {
                     onChange={(e) => setNewUser({ ...newUser, username: e.target.value })}
                     required
                   />
-                </div>
-
-                <div className="form-group">
-                  <label htmlFor="new-password">Password</label>
-                  <input
-                    type="password"
-                    id="new-password"
-                    value={newUser.password}
-                    onChange={(e) => setNewUser({ ...newUser, password: e.target.value })}
-                    required
-                    minLength="6"
-                  />
-                  <small style={{ color: '#7f8c8d', display: 'block', marginTop: '0.25rem' }}>
-                    Must be at least 6 characters
-                  </small>
                 </div>
 
                 <div className="form-group">
@@ -386,6 +372,67 @@ function UserManagement({ currentUser }) {
                 </button>
               </div>
             </form>
+          </div>
+        </div>
+      )}
+
+      {/* Activation Code Modal */}
+      {showActivationCodeModal && (
+        <div className="modal-overlay" onClick={() => setShowActivationCodeModal(false)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()} style={{ maxWidth: '500px' }}>
+            <div className="modal-header">
+              <h3>✅ User Created Successfully</h3>
+              <button className="close-btn" onClick={() => setShowActivationCodeModal(false)}>×</button>
+            </div>
+            <div className="modal-body">
+              <p style={{ color: '#7f8c8d', marginBottom: '1rem' }}>
+                Share this activation code with the user. They will use it to set up their passkey.
+                <strong style={{ display: 'block', marginTop: '0.5rem', color: '#e74c3c' }}>
+                  This code will only be shown once!
+                </strong>
+              </p>
+
+              <div style={{
+                background: '#f8f9fa',
+                padding: '1.5rem',
+                borderRadius: '4px',
+                border: '2px solid #3498db',
+                textAlign: 'center',
+                marginBottom: '1rem'
+              }}>
+                <div style={{
+                  fontSize: '2rem',
+                  fontFamily: 'monospace',
+                  letterSpacing: '0.3em',
+                  fontWeight: 'bold',
+                  color: '#2c3e50'
+                }}>
+                  {activationCode}
+                </div>
+              </div>
+
+              <button
+                className="btn btn-secondary"
+                onClick={() => {
+                  navigator.clipboard.writeText(activationCode);
+                  setSuccess('Activation code copied to clipboard!');
+                }}
+                style={{ width: '100%', marginBottom: '0.5rem' }}
+              >
+                📋 Copy to Clipboard
+              </button>
+            </div>
+            <div className="modal-footer">
+              <button
+                className="btn btn-primary"
+                onClick={() => {
+                  setShowActivationCodeModal(false);
+                  setActivationCode('');
+                }}
+              >
+                Done
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -20,7 +20,8 @@ case "$TEST_SUITE" in
 esac
 
 echo "================================"
-echo "Freezer Inventory Tracker"
+echo "Freezer Inventory Tracker v1.2"
+echo "Features: Passkey Auth, QR Codes, History Tracking"
 if [ "$TEST_SUITE" = "all" ]; then
     echo "Running All Tests"
 else


### PR DESCRIPTION
User Management changes:
- Remove password field from Add User modal
- Generate activation code instead of password
- Display activation code in modal with copy button
- Show "This code will only be shown once!" warning
- Add helpful description about passkey enrollment

Backend integration:
- Updated to use existing /register endpoint that returns activation_code
- Frontend now properly displays the one-time code to admin

run-tests.sh update:
- Add version number (v1.2) and feature list to test output
- Features listed: Passkey Auth, QR Codes, History Tracking

Workflow:
1. Admin creates user (username + role only)
2. System generates 8-character activation code
3. Admin sees code in modal and can copy it
4. Admin shares code with user
5. User enters code on login page
6. User sets up passkey and gets recovery codes