### PR TITLE
Add backend restart session invalidation

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4,9 +4,14 @@ from flask_jwt_extended import JWTManager
 from models import db, User, Category, Setting
 from dotenv import load_dotenv
 import os
+import uuid
 
 # Load environment variables from .env file
 load_dotenv()
+
+# Generate unique boot ID when the app starts
+# This invalidates all existing tokens when the backend restarts
+BOOT_ID = str(uuid.uuid4())
 
 def create_app(test_config=None):
     app = Flask(__name__)
@@ -39,10 +44,38 @@ def create_app(test_config=None):
         # Test configuration
         app.config.update(test_config)
 
+    # Store boot ID in app config for access in routes
+    app.config['BOOT_ID'] = BOOT_ID
+
     # Initialize extensions
     db.init_app(app)
     CORS(app)
-    JWTManager(app)
+    jwt = JWTManager(app)
+
+    # Verify boot_id in JWT tokens to invalidate old tokens after restart
+    @jwt.token_verification_loader
+    def verify_token_boot_id(jwt_header, jwt_data):
+        """Verify that the token's boot_id matches the current boot_id"""
+        boot_id_in_token = jwt_data.get('boot_id')
+        # If there's no boot_id in the token (old tokens), reject it
+        # If boot_id doesn't match current boot_id, reject it
+        return boot_id_in_token == BOOT_ID
+
+    @jwt.token_verification_failed_loader
+    def token_verification_failed_callback(jwt_header, jwt_data):
+        return jsonify({'error': 'session_expired', 'message': 'Backend restarted. Please log in again.'}), 401
+
+    @jwt.expired_token_loader
+    def expired_token_callback(jwt_header, jwt_data):
+        return jsonify({'error': 'token_expired', 'message': 'Token has expired. Please log in again.'}), 401
+
+    @jwt.invalid_token_loader
+    def invalid_token_callback(error):
+        return jsonify({'error': 'invalid_token', 'message': 'Token is invalid. Please log in again.'}), 401
+
+    @jwt.unauthorized_loader
+    def unauthorized_callback(error):
+        return jsonify({'error': 'missing_token', 'message': 'Authorization token is missing'}), 401
 
     # Register blueprints
     from routes.auth import auth_bp
@@ -160,6 +193,7 @@ if __name__ == '__main__':
     print("\n" + "="*50)
     print("Freezer Inventory Tracker API")
     print("="*50)
+    print(f"Boot ID: {BOOT_ID[:8]}... (all existing sessions invalidated)")
     print("Server running on http://localhost:5001")
     print("Default admin credentials:")
     print("  Username: admin")

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -71,10 +71,15 @@ def activate():
     db.session.commit()
 
     # Create token for passkey registration (24 hour expiration)
+    from flask import current_app
     access_token = create_access_token(
         identity=str(user.id),
         expires_delta=timedelta(hours=24),
-        additional_claims={'role': user.role, 'username': user.username}
+        additional_claims={
+            'role': user.role,
+            'username': user.username,
+            'boot_id': current_app.config['BOOT_ID']
+        }
     )
 
     return jsonify({
@@ -100,10 +105,15 @@ def login():
         return jsonify({'error': 'Invalid username or password'}), 401
 
     # Create access token with 24 hour expiration
+    from flask import current_app
     access_token = create_access_token(
         identity=str(user.id),
         expires_delta=timedelta(hours=24),
-        additional_claims={'role': user.role, 'username': user.username}
+        additional_claims={
+            'role': user.role,
+            'username': user.username,
+            'boot_id': current_app.config['BOOT_ID']
+        }
     )
 
     return jsonify({
@@ -406,10 +416,15 @@ def quick_login():
         return jsonify({'error': 'User not found'}), 404
 
     # Create access token (same as regular login)
+    from flask import current_app
     access_token = create_access_token(
         identity=str(user.id),
         expires_delta=timedelta(hours=24),
-        additional_claims={'role': user.role, 'username': user.username}
+        additional_claims={
+            'role': user.role,
+            'username': user.username,
+            'boot_id': current_app.config['BOOT_ID']
+        }
     )
 
     return jsonify({

--- a/backend/routes/passkey.py
+++ b/backend/routes/passkey.py
@@ -374,10 +374,15 @@ def login_complete():
             return jsonify({'error': 'User not found'}), 404
 
         # Create JWT token
+        from flask import current_app
         access_token = create_access_token(
             identity=str(user.id),
             expires_delta=timedelta(hours=24),
-            additional_claims={'role': user.role, 'username': user.username}
+            additional_claims={
+                'role': user.role,
+                'username': user.username,
+                'boot_id': current_app.config['BOOT_ID']
+            }
         )
 
         return jsonify({
@@ -473,9 +478,11 @@ def use_recovery_code():
 
     # Create temporary token (short expiration - 15 minutes)
     from datetime import timedelta
+    from flask import current_app
     access_token = create_access_token(
         identity=str(user.id),
-        expires_delta=timedelta(minutes=15)
+        expires_delta=timedelta(minutes=15),
+        additional_claims={'boot_id': current_app.config['BOOT_ID']}
     )
 
     return jsonify({'temporaryToken': access_token})

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -16,6 +16,53 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+// Handle auth errors and auto-logout
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    // Check if it's an authentication error
+    if (error.response) {
+      const { status, data } = error.response;
+
+      // Auth errors: 401 Unauthorized or 403 Forbidden
+      if (status === 401 || status === 403) {
+        // Clear stored auth data
+        localStorage.removeItem('token');
+        localStorage.removeItem('user');
+
+        // Redirect to login page if not already there
+        if (!window.location.pathname.includes('/login') &&
+            !window.location.pathname.includes('/activate')) {
+          window.location.href = '/login';
+        }
+      }
+
+      // Also handle 500 errors that might be DB connection issues
+      if (status === 500 && data?.error) {
+        // If the error message suggests a backend issue, clear session
+        const backendErrorPatterns = [
+          'database',
+          'connection',
+          'backend',
+          'server error'
+        ];
+        const errorMessage = (data.error || '').toLowerCase();
+
+        if (backendErrorPatterns.some(pattern => errorMessage.includes(pattern))) {
+          localStorage.removeItem('token');
+          localStorage.removeItem('user');
+
+          if (!window.location.pathname.includes('/login')) {
+            window.location.href = '/login';
+          }
+        }
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
+
 // Auth API
 export const authAPI = {
   login: (username, password) =>


### PR DESCRIPTION
Automatically invalidate all user sessions when backend restarts to prevent stale token issues and improve user experience.

Backend changes:
- Generate unique boot_id (UUID) on backend startup
- Add boot_id to all JWT tokens as additional claim
- Validate boot_id in JWT verification to reject old tokens
- Return clear error messages (session_expired) when tokens are invalid
- Log boot_id on startup for debugging

Frontend changes:
- Add axios response interceptor to catch auth errors (401/403)
- Auto-logout and redirect to login on authentication failures
- Also handle 500 errors with database/connection issues
- Clear localStorage and redirect without user intervention

Benefits:
- Users no longer stuck with invalid tokens after backend restart
- Silent, automatic logout provides better UX
- Prevents "odd behavior" from stale session state
- Proactive solution that works for all restart scenarios

Related #198