### PR TITLE
Fix boot_id verification for Flask-JWT-Extended 4.x

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -52,21 +52,30 @@ def create_app(test_config=None):
     CORS(app)
     jwt = JWTManager(app)
 
-    # Verify boot_id in JWT tokens to invalidate old tokens after restart
-    @jwt.token_verification_loader
-    def verify_token_boot_id(jwt_header, jwt_data):
-        """Verify that the token's boot_id matches the current boot_id"""
-        boot_id_in_token = jwt_data.get('boot_id')
-        # If there's no boot_id in the token (old tokens), reject it
-        # If boot_id doesn't match current boot_id, reject it
-        return boot_id_in_token == BOOT_ID
+    # Add boot_id to all tokens automatically
+    @jwt.additional_claims_loader
+    def add_claims_to_jwt(identity):
+        return {'boot_id': BOOT_ID}
 
-    @jwt.token_verification_failed_loader
-    def token_verification_failed_callback(jwt_header, jwt_data):
-        return jsonify({'error': 'session_expired', 'message': 'Backend restarted. Please log in again.'}), 401
+    # Use token_in_blocklist_loader to check boot_id mismatch
+    # This treats tokens with wrong boot_id as "revoked"
+    @jwt.token_in_blocklist_loader
+    def check_if_token_revoked(jwt_header, jwt_payload):
+        """Check if token's boot_id matches current boot_id"""
+        token_boot_id = jwt_payload.get('boot_id')
+        # Revoke tokens that don't have boot_id or have mismatched boot_id
+        return token_boot_id != BOOT_ID
+
+    @jwt.revoked_token_loader
+    def revoked_token_callback(jwt_header, jwt_payload):
+        """Handle revoked tokens (wrong boot_id = revoked)"""
+        return jsonify({
+            'error': 'session_expired',
+            'message': 'Backend restarted. Please log in again.'
+        }), 401
 
     @jwt.expired_token_loader
-    def expired_token_callback(jwt_header, jwt_data):
+    def expired_token_callback(jwt_header, jwt_payload):
         return jsonify({'error': 'token_expired', 'message': 'Token has expired. Please log in again.'}), 401
 
     @jwt.invalid_token_loader

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -71,15 +71,10 @@ def activate():
     db.session.commit()
 
     # Create token for passkey registration (24 hour expiration)
-    from flask import current_app
     access_token = create_access_token(
         identity=str(user.id),
         expires_delta=timedelta(hours=24),
-        additional_claims={
-            'role': user.role,
-            'username': user.username,
-            'boot_id': current_app.config['BOOT_ID']
-        }
+        additional_claims={'role': user.role, 'username': user.username}
     )
 
     return jsonify({
@@ -105,15 +100,10 @@ def login():
         return jsonify({'error': 'Invalid username or password'}), 401
 
     # Create access token with 24 hour expiration
-    from flask import current_app
     access_token = create_access_token(
         identity=str(user.id),
         expires_delta=timedelta(hours=24),
-        additional_claims={
-            'role': user.role,
-            'username': user.username,
-            'boot_id': current_app.config['BOOT_ID']
-        }
+        additional_claims={'role': user.role, 'username': user.username}
     )
 
     return jsonify({
@@ -416,15 +406,10 @@ def quick_login():
         return jsonify({'error': 'User not found'}), 404
 
     # Create access token (same as regular login)
-    from flask import current_app
     access_token = create_access_token(
         identity=str(user.id),
         expires_delta=timedelta(hours=24),
-        additional_claims={
-            'role': user.role,
-            'username': user.username,
-            'boot_id': current_app.config['BOOT_ID']
-        }
+        additional_claims={'role': user.role, 'username': user.username}
     )
 
     return jsonify({

--- a/backend/routes/passkey.py
+++ b/backend/routes/passkey.py
@@ -374,15 +374,10 @@ def login_complete():
             return jsonify({'error': 'User not found'}), 404
 
         # Create JWT token
-        from flask import current_app
         access_token = create_access_token(
             identity=str(user.id),
             expires_delta=timedelta(hours=24),
-            additional_claims={
-                'role': user.role,
-                'username': user.username,
-                'boot_id': current_app.config['BOOT_ID']
-            }
+            additional_claims={'role': user.role, 'username': user.username}
         )
 
         return jsonify({
@@ -478,11 +473,9 @@ def use_recovery_code():
 
     # Create temporary token (short expiration - 15 minutes)
     from datetime import timedelta
-    from flask import current_app
     access_token = create_access_token(
         identity=str(user.id),
-        expires_delta=timedelta(minutes=15),
-        additional_claims={'boot_id': current_app.config['BOOT_ID']}
+        expires_delta=timedelta(minutes=15)
     )
 
     return jsonify({'temporaryToken': access_token})


### PR DESCRIPTION
The previous implementation used decorators that don't exist in Flask-JWT-Extended 4.x:
- @jwt.token_verification_loader (doesn't exist)
- @jwt.token_verification_failed_loader (doesn't exist)

Fixed by using the correct decorators for v4.x:
- @jwt.additional_claims_loader: Automatically adds boot_id to all tokens
- @jwt.token_in_blocklist_loader: Checks if token's boot_id mismatches (treats as revoked)
- @jwt.revoked_token_loader: Handles revoked tokens (mismatched boot_id)

Also removed manual boot_id additions from routes since it's now automatic.

This will properly invalidate all tokens when backend restarts.