### PR TITLE
Potential fix for code scanning alert no. 25: Information exposure through an exception

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -330,7 +330,7 @@ def regenerate_activation_code(user_id):
     except Exception as e:
         db.session.rollback()
         print(f'Error regenerating activation code: {str(e)}')
-        return jsonify({'error': f'Failed to regenerate activation code: {str(e)}'}), 500
+        return jsonify({'error': 'Failed to regenerate activation code'}), 500
 
 
 @auth_bp.route('/quick-login-status', methods=['GET'])


### PR DESCRIPTION
Potential fix for [https://github.com/usfbullsfan/home-freezer-inventory/security/code-scanning/25](https://github.com/usfbullsfan/home-freezer-inventory/security/code-scanning/25)

In general, the problem should be fixed by not including raw exception information in HTTP responses. Instead, log the exception server-side (potentially with stack trace) and send a generic error message to the client that does not reveal internal implementation details.

For this specific case in `backend/routes/auth.py`, we should change the `except` block in `regenerate_activation_code` so that:
- it still rolls back the database session on error;
- it logs the error (optionally with a traceback) to server logs; and
- it returns a stable, generic error message such as `"Failed to regenerate activation code"` without appending `str(e)`.

We can reuse the existing `print`-based logging but should remove the `str(e)` from the client-facing message. We do not need new imports or dependencies: printing to stdout (or, if already available elsewhere in the file, Flask’s `current_app.logger`) is enough for logging. The only lines to change are around 330–333 in `backend/routes/auth.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
