### PR TITLE
Update Werkzeug to 3.1.5 to fix security vulnerability

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,7 +4,7 @@ Flask-CORS==6.0.2
 Flask-JWT-Extended==4.7.1
 qrcode[pil]==8.2
 python-dotenv==1.2.1
-Werkzeug==3.1.4
+Werkzeug==3.1.5
 gunicorn==23.0.0
 requests==2.32.5
 reportlab==4.4.7


### PR DESCRIPTION
Fixes Dependabot alert: Werkzeug safe_join() allows Windows special device names with compound extensions.

Werkzeug 3.1.5 is compatible with Flask 3.1.2.