### PR TITLE
Fix boot_id for multi-worker gunicorn deployments (main)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ build/
 *.sqlite
 *.sqlite3
 
+# Runtime state
+backend/instance/.boot_id
+
 # Node
 node_modules/
 npm-debug.log*

--- a/backend/app.py
+++ b/backend/app.py
@@ -5,13 +5,37 @@ from models import db, User, Category, Setting
 from dotenv import load_dotenv
 import os
 import uuid
+import time
 
 # Load environment variables from .env file
 load_dotenv()
 
 # Generate unique boot ID when the app starts
 # This invalidates all existing tokens when the backend restarts
-BOOT_ID = str(uuid.uuid4())
+# Stored in a file so all gunicorn workers share the same boot_id
+def get_or_create_boot_id():
+    """Get or create boot ID that persists across gunicorn workers"""
+    boot_id_file = os.path.join(os.path.dirname(__file__), 'instance', '.boot_id')
+
+    # Ensure instance directory exists
+    os.makedirs(os.path.dirname(boot_id_file), exist_ok=True)
+
+    # Check if boot_id file exists and was created recently (within last 5 minutes)
+    # This handles both app restart and ensures stale files are replaced
+    if os.path.exists(boot_id_file):
+        file_age = time.time() - os.path.getmtime(boot_id_file)
+        if file_age < 300:  # 5 minutes
+            with open(boot_id_file, 'r') as f:
+                return f.read().strip()
+
+    # Generate new boot_id and save it
+    boot_id = str(uuid.uuid4())
+    with open(boot_id_file, 'w') as f:
+        f.write(boot_id)
+
+    return boot_id
+
+BOOT_ID = get_or_create_boot_id()
 
 def create_app(test_config=None):
     app = Flask(__name__)


### PR DESCRIPTION
Store boot_id in a file shared across all gunicorn workers to prevent immediate logout issues in production.

Previously, each gunicorn worker generated its own boot_id, causing tokens created by one worker to be rejected by another worker.

Now:

boot_id is stored in backend/instance/.boot_id
All workers read the same boot_id
File is regenerated on restart (5 minute TTL)
Added .boot_id to .gitignore
Fixes instant logout issue on production (main).