### PR TITLE
Fix FeedbackModal missing CSS import

### DIFF
--- a/frontend/src/components/FeedbackModal.jsx
+++ b/frontend/src/components/FeedbackModal.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import './Modal.css';
 
 function FeedbackModal({ isOpen, onClose }) {
   const [type, setType] = useState('bug');


### PR DESCRIPTION
Remove non-existent Modal.css import - component uses App.css classes which already define modal-overlay, modal-header, modal-body, etc. Component primarily uses inline styles anyway.