### PR TITLE
Fix feedback.py import error - remove 'backend.' prefix

### DIFF
--- a/backend/routes/feedback.py
+++ b/backend/routes/feedback.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, request, jsonify
 from flask_jwt_extended import jwt_required, get_jwt_identity
-from backend.database import get_db_connection
+from database import get_db_connection
 from datetime import datetime
 import subprocess
 import os


### PR DESCRIPTION
Changed from 'from backend.database import get_db_connection' to 'from database import get_db_connection' to match other route files.

This fixes the ModuleNotFoundError that was preventing the backend from starting.