### PR TITLE
Detect and provide instructions for missing GitHub CLI

### DIFF
--- a/backend/process_github_issues.py
+++ b/backend/process_github_issues.py
@@ -56,11 +56,11 @@ def create_github_issue(feedback):
 
     # Determine label and emoji
     if feedback_type == 'bug':
-        label = 'Bug'
+        label = 'bug'
         emoji = '🐛'
         title_prefix = 'Bug'
     else:
-        label = 'Enhancement'
+        label = 'enhancement'
         emoji = '✨'
         title_prefix = 'Enhancement'
 


### PR DESCRIPTION
- Distinguish between 'gh not installed' vs 'gh not authenticated'
- Return None from check_gh_auth() when gh command not found
- Provide installation instructions for Ubuntu/Debian
- Clearer error messages for each scenario

This fixes the misleading "not authenticated" error when gh isn't even installed.