### PR TITLE
Fix auto-logout issue by removing boot_id time-based expiry

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -89,6 +89,11 @@ jobs:
             cd ..
             echo "✓ Frontend built"
 
+            # Delete boot_id file to invalidate all sessions on deployment
+            echo "Invalidating existing sessions..."
+            rm -f backend/instance/.boot_id
+            echo "✓ Sessions will be invalidated on restart"
+
             # Restart services
             echo "Restarting services..."
             sudo systemctl restart freezer-backend-dev

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -89,6 +89,11 @@ jobs:
             cd ..
             echo "✓ Frontend built"
 
+            # Delete boot_id file to invalidate all sessions on deployment
+            echo "Invalidating existing sessions..."
+            rm -f backend/instance/.boot_id
+            echo "✓ Sessions will be invalidated on restart"
+
             # Restart services
             echo "Restarting services..."
             sudo systemctl restart freezer-backend

--- a/backend/app.py
+++ b/backend/app.py
@@ -5,7 +5,6 @@ from models import db, User, Category, Setting
 from dotenv import load_dotenv
 import os
 import uuid
-import time
 
 # Load environment variables from .env file
 load_dotenv()
@@ -14,19 +13,24 @@ load_dotenv()
 # This invalidates all existing tokens when the backend restarts
 # Stored in a file so all gunicorn workers share the same boot_id
 def get_or_create_boot_id():
-    """Get or create boot ID that persists across gunicorn workers"""
+    """Get or create boot ID that persists across gunicorn workers
+
+    The boot_id file should be deleted by deployment scripts before service restart
+    to ensure all tokens are invalidated on actual deployments/restarts.
+
+    We do NOT use time-based expiry because in multi-worker environments,
+    workers can start at different times, and we need all workers to share
+    the same boot_id for the entire service lifetime.
+    """
     boot_id_file = os.path.join(os.path.dirname(__file__), 'instance', '.boot_id')
 
     # Ensure instance directory exists
     os.makedirs(os.path.dirname(boot_id_file), exist_ok=True)
 
-    # Check if boot_id file exists and was created recently (within last 5 minutes)
-    # This handles both app restart and ensures stale files are replaced
+    # If boot_id file exists, use it (all workers must share the same boot_id)
     if os.path.exists(boot_id_file):
-        file_age = time.time() - os.path.getmtime(boot_id_file)
-        if file_age < 300:  # 5 minutes
-            with open(boot_id_file, 'r') as f:
-                return f.read().strip()
+        with open(boot_id_file, 'r') as f:
+            return f.read().strip()
 
     # Generate new boot_id and save it
     boot_id = str(uuid.uuid4())


### PR DESCRIPTION
The previous implementation had a 5-minute TTL on the boot_id file, which
caused auto-logout issues in multi-worker gunicorn deployments.

Problem:
- When a gunicorn worker restarted after 5+ minutes, it would see the
  boot_id file as "too old" and generate a new boot_id
- This invalidated all existing user tokens, causing immediate logout
- Different workers could end up with different boot_ids in memory

Solution:
- Removed time-based expiry check from get_or_create_boot_id()
- Boot_id file now persists for the entire service lifetime
- All workers share the same boot_id regardless of when they start
- Added explicit boot_id file deletion in deployment workflows
- This ensures tokens are only invalidated on actual deployments/restarts

Changes:
- backend/app.py: Remove 5-minute TTL check, update docstrings
- .github/workflows/deploy-prod-gcp.yml: Delete .boot_id before restart
- .github/workflows/deploy-dev-gcp.yml: Delete .boot_id before restart
- Removed unused 'time' import

This fix ensures stable authentication across worker restarts while still
invalidating sessions on deployments as intended.