### PR TITLE
Fix gunicorn worker race condition for boot_id

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -100,6 +100,8 @@ jobs:
             # Delete boot_id file to invalidate all sessions on deployment
             echo "Invalidating existing sessions..."
             rm -f backend/instance/.boot_id
+            # Pre-create boot_id file to avoid race condition with multiple workers
+            python3 -c "import uuid; open('backend/instance/.boot_id', 'w').write(str(uuid.uuid4()))"
             echo "✓ Sessions will be invalidated on restart"
 
             # Restart services

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -100,6 +100,8 @@ jobs:
             # Delete boot_id file to invalidate all sessions on deployment
             echo "Invalidating existing sessions..."
             rm -f backend/instance/.boot_id
+            # Pre-create boot_id file to avoid race condition with multiple workers
+            python3 -c "import uuid; open('backend/instance/.boot_id', 'w').write(str(uuid.uuid4()))"
             echo "✓ Sessions will be invalidated on restart"
 
             # Restart services


### PR DESCRIPTION
When multiple gunicorn workers start simultaneously after deployment, they can create different boot_id values, causing immediate logout:
- Worker 1 generates boot_id A and stores in memory
- Worker 2 generates boot_id B and stores in memory
- Login request → Worker 1 → token with boot_id A
- Next API request → Worker 2 → rejects token (expects B) → 401 logout

Solution: Pre-create the boot_id file before starting gunicorn workers. All workers will read the same existing file instead of creating new ones.

Changes:
- Generate boot_id file immediately after deleting it
- Workers now read existing file instead of creating new ones
- Eliminates race condition between worker startups

Fixes immediate logout issue after deployment.