### PR TITLE
Improve AddItemModal form reset behavior and date handling

### DIFF
--- a/frontend/src/components/AddItemModal.jsx
+++ b/frontend/src/components/AddItemModal.jsx
@@ -323,23 +323,20 @@ function AddItemModal({ item, categories, onClose, onSave, onCategoryCreated }) 
       }
 
       if (keepOpen) {
-        // Reset form for next entry, but keep category selected
-        const savedCategoryId = formData.category_id;
-        const savedCategoryExpiration = formData.expiration_date;
-
-        setFormData({
+        // Reset form for next entry, keeping name/source/category/date but clearing weight and item-specific fields
+        setFormData((prev) => ({
           qr_code: '',
           upc: '',
           image_url: '',
-          name: '',
-          source: '',
+          name: prev.name,
+          source: prev.source,
           weight: '',
-          weight_unit: 'lb',
-          category_id: savedCategoryId,
-          added_date: '',
-          expiration_date: savedCategoryExpiration,
+          weight_unit: prev.weight_unit,
+          category_id: prev.category_id,
+          added_date: prev.added_date,
+          expiration_date: prev.expiration_date,
           notes: '',
-        });
+        }));
         setUpcMessage('');
 
         // Trigger a soft refresh to update the items list in the background


### PR DESCRIPTION
## Summary
Enhanced the AddItemModal component to provide a better user experience when adding multiple items in succession. The form now intelligently preserves user-selected values (name, source, category, dates, and weight unit) while clearing item-specific fields, and initializes the added_date field with today's date.

## Key Changes
- **Date initialization**: Import and use `toDateInputValue()` utility to set `added_date` to today's date by default instead of an empty string
- **Improved form reset logic**: When "Keep Open" is selected after saving an item, the form now:
  - Preserves user-entered values: `name`, `source`, `category_id`, `weight_unit`, `added_date`, and `expiration_date`
  - Clears item-specific fields: `qr_code`, `upc`, `image_url`, `weight`, and `notes`
  - Uses functional state update (`setFormData((prev) => ...)`) to reference previous form state instead of temporary variables
- **Better UX for batch entry**: Users can now quickly add multiple items with the same category and dates without re-entering these values each time

## Implementation Details
- Replaced imperative variable assignments (`savedCategoryId`, `savedCategoryExpiration`) with a functional state update pattern for cleaner code
- The form reset now intelligently distinguishes between "persistent" fields (that should carry over) and "transient" fields (that should be cleared for the next item)

https://claude.ai/code/session_01HwTEc2gQwgjWRQGvMhPY2p