### PR TITLE
Add admin setting to enable/disable QR code printing

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -222,6 +222,20 @@ def create_app(test_config=None):
                 db.session.add(enable_images_setting)
                 print("Created system setting: enable_image_fetching = true")
 
+            enable_qr_printing_setting = Setting.query.filter_by(
+                user_id=None,
+                setting_name='enable_qr_printing'
+            ).first()
+
+            if not enable_qr_printing_setting:
+                enable_qr_printing_setting = Setting(
+                    user_id=None,
+                    setting_name='enable_qr_printing',
+                    setting_value='true'
+                )
+                db.session.add(enable_qr_printing_setting)
+                print("Created system setting: enable_qr_printing = true")
+
             db.session.commit()
 
     return app

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,7 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Link, Navigate, useLocation, us
 import './App.css';
 import { clearSession } from './utils/sessionTracking';
 import { isMobileDevice, isDesktopSiteRequested, getLogoPath } from './utils/deviceDetection';
-import api from './services/api';
+import api, { settingsAPI } from './services/api';
 import FeedbackModal from './components/FeedbackModal';
 
 // Lazy load route components for better code splitting
@@ -22,6 +22,7 @@ function AppContent() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const [useDesktopInterface, setUseDesktopInterface] = useState(false);
+  const [qrPrintingEnabled, setQrPrintingEnabled] = useState(true);
   const [feedbackModalOpen, setFeedbackModalOpen] = useState(false);
   const location = useLocation();
   const navigate = useNavigate();
@@ -67,15 +68,22 @@ function AppContent() {
       // Only update if changed
       setIsMobile(prev => prev === newIsMobile ? prev : newIsMobile);
 
-      // If user is logged in, check their desktop interface preference
+      // If user is logged in, check their desktop interface preference and system settings
       if (user) {
         try {
-          const response = await api.get('/settings/user');
-          const settings = response.data;
-          const desktopPref = settings.find(s => s.setting_name === 'use_desktop_interface');
+          const [userResponse, systemResponse] = await Promise.all([
+            api.get('/settings/user'),
+            settingsAPI.getSystemSettings(),
+          ]);
 
+          const settings = userResponse.data;
+          const desktopPref = settings.find(s => s.setting_name === 'use_desktop_interface');
           const shouldUseDesktop = desktopPref && desktopPref.setting_value === 'true';
           setUseDesktopInterface(prev => prev === shouldUseDesktop ? prev : shouldUseDesktop);
+
+          const systemSettings = systemResponse.data;
+          const qrEnabled = systemSettings.enable_qr_printing !== 'false';
+          setQrPrintingEnabled(qrEnabled);
         } catch (error) {
           console.error('Error fetching user preferences:', error);
         }
@@ -160,7 +168,9 @@ function AppContent() {
                       <summary>Manage</summary>
                       <div className="navbar-submenu-items">
                         <Link to="/categories" onClick={() => setMobileMenuOpen(false)}>Categories</Link>
-                        <Link to="/print-labels" onClick={() => setMobileMenuOpen(false)}>Print Labels</Link>
+                        {qrPrintingEnabled && (
+                          <Link to="/print-labels" onClick={() => setMobileMenuOpen(false)}>Print Labels</Link>
+                        )}
                       </div>
                     </details>
                     <Link to="/settings" className="navbar-settings-link" onClick={() => setMobileMenuOpen(false)}>⚙️ Settings</Link>
@@ -170,7 +180,9 @@ function AppContent() {
                   <>
                     <Link to="/" onClick={() => setMobileMenuOpen(false)}>Inventory</Link>
                     <Link to="/categories" onClick={() => setMobileMenuOpen(false)}>Categories</Link>
-                    <Link to="/print-labels" onClick={() => setMobileMenuOpen(false)}>Print Labels</Link>
+                    {qrPrintingEnabled && (
+                      <Link to="/print-labels" onClick={() => setMobileMenuOpen(false)}>Print Labels</Link>
+                    )}
                     <Link to="/settings" onClick={() => setMobileMenuOpen(false)}>Settings</Link>
                   </>
                 )}
@@ -189,9 +201,9 @@ function AppContent() {
               {showMobileInterface ? (
                 // Mobile routes
                 <>
-                  <Route path="/home" element={<MobileLanding />} />
+                  <Route path="/home" element={<MobileLanding qrPrintingEnabled={qrPrintingEnabled} />} />
                   <Route path="/" element={<Navigate to="/home" replace />} />
-                  <Route path="/inventory" element={<Inventory isMobile={true} />} />
+                  <Route path="/inventory" element={<Inventory isMobile={true} qrPrintingEnabled={qrPrintingEnabled} />} />
                   <Route path="/item/:qrCode" element={<QRRedirect />} />
                   <Route path="/categories" element={<Categories />} />
                   <Route path="/print-labels" element={<PrintLabels />} />
@@ -201,7 +213,7 @@ function AppContent() {
               ) : (
                 // Desktop routes (unchanged)
                 <>
-                  <Route path="/" element={<Inventory />} />
+                  <Route path="/" element={<Inventory qrPrintingEnabled={qrPrintingEnabled} />} />
                   <Route path="/item/:qrCode" element={<QRRedirect />} />
                   <Route path="/categories" element={<Categories />} />
                   <Route path="/print-labels" element={<PrintLabels />} />

--- a/frontend/src/components/ItemCard.jsx
+++ b/frontend/src/components/ItemCard.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { itemsAPI } from '../services/api';
 import { formatLocalDate, daysBetween } from '../utils/dateUtils';
 
-function ItemCard({ item, onEdit, onStatusChange }) {
+function ItemCard({ item, onEdit, onStatusChange, qrPrintingEnabled = true }) {
   const [showQR, setShowQR] = useState(false);
 
   const getStatusClass = () => {
@@ -115,13 +115,15 @@ function ItemCard({ item, onEdit, onStatusChange }) {
       </div>
 
       <div className="item-actions">
-        <button
-          className="btn btn-secondary"
-          onClick={() => setShowQR(!showQR)}
-          style={{ flex: 0.5 }}
-        >
-          Code
-        </button>
+        {qrPrintingEnabled && (
+          <button
+            className="btn btn-secondary"
+            onClick={() => setShowQR(!showQR)}
+            style={{ flex: 0.5 }}
+          >
+            Code
+          </button>
+        )}
         <button
           className="btn btn-primary"
           onClick={onEdit}
@@ -154,7 +156,7 @@ function ItemCard({ item, onEdit, onStatusChange }) {
         )}
       </div>
 
-      {showQR && (
+      {qrPrintingEnabled && showQR && (
         <div className="qr-code-display">
           <p style={{ marginBottom: '0.5rem', fontWeight: 'bold' }}>
             {item.qr_code}

--- a/frontend/src/pages/Inventory.jsx
+++ b/frontend/src/pages/Inventory.jsx
@@ -7,7 +7,7 @@ import QRInputModal from '../components/QRInputModal';
 import QRScanner from '../components/QRScanner';
 import SessionBanner from '../components/SessionBanner';
 
-function Inventory({ isMobile = false }) {
+function Inventory({ isMobile = false, qrPrintingEnabled = true }) {
   const [items, setItems] = useState([]);
   const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -263,7 +263,7 @@ function Inventory({ isMobile = false }) {
 
   return (
     <div className="container">
-      <SessionBanner key={sessionKey} />
+      {qrPrintingEnabled && <SessionBanner key={sessionKey} />}
 
       <div className="inventory-header">
         <div>
@@ -284,9 +284,11 @@ function Inventory({ isMobile = false }) {
             <button className="btn btn-secondary" onClick={() => setShowQRModal(true)}>
               🔍 Locate Item by Code
             </button>
-            <button className="btn btn-secondary" onClick={() => setShowQRScanner(true)}>
-              📷 Scan QR Code
-            </button>
+            {qrPrintingEnabled && (
+              <button className="btn btn-secondary" onClick={() => setShowQRScanner(true)}>
+                📷 Scan QR Code
+              </button>
+            )}
             <button className="btn btn-success" onClick={handleAddItem}>
               ➕ Add Item
             </button>
@@ -388,6 +390,7 @@ function Inventory({ isMobile = false }) {
               item={item}
               onEdit={() => handleEditItem(item)}
               onStatusChange={(status) => handleStatusChange(item.id, status)}
+              qrPrintingEnabled={qrPrintingEnabled}
             />
           ))}
         </div>

--- a/frontend/src/pages/MobileLanding.jsx
+++ b/frontend/src/pages/MobileLanding.jsx
@@ -7,7 +7,7 @@ import './MobileLanding.css';
  * Simple, touch-friendly landing page for mobile users
  * Shows three main action buttons
  */
-const MobileLanding = () => {
+const MobileLanding = ({ qrPrintingEnabled = true }) => {
   const navigate = useNavigate();
 
   const actions = [
@@ -27,14 +27,14 @@ const MobileLanding = () => {
       action: () => navigate('/inventory'),
       color: '#2196f3'
     },
-    {
+    ...(qrPrintingEnabled ? [{
       id: 'scan',
       title: 'Scan QR Code',
       description: 'Locate an item by scanning its code',
       icon: '📷',
       action: () => navigate('/inventory?action=scan'),
       color: '#ff9800'
-    }
+    }] : [])
   ];
 
   return (

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -14,6 +14,7 @@ function Settings({ user, isMobile = false, setUseDesktopInterface }) {
   const [systemSettings, setSystemSettings] = useState({
     enable_image_fetching: 'true',
     no_auth_mode: 'false',
+    enable_qr_printing: 'true',
   });
   const [userSettings, setUserSettings] = useState({
     use_desktop_interface: 'false',
@@ -648,6 +649,26 @@ function Settings({ user, isMobile = false, setUseDesktopInterface }) {
             </label>
             <small style={{ color: '#7f8c8d', marginLeft: '1.5rem', display: 'block', marginTop: '0.25rem' }}>
               When enabled, the system will automatically fetch product images from Pexels when adding items via UPC lookup. Disable this to conserve API quota or bandwidth.
+            </small>
+          </div>
+
+          <div className="form-group" style={{ marginBottom: '1.5rem' }}>
+            <label style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={systemSettings.enable_qr_printing === 'true'}
+                onChange={(e) =>
+                  setSystemSettings({
+                    ...systemSettings,
+                    enable_qr_printing: e.target.checked ? 'true' : 'false',
+                  })
+                }
+                style={{ marginRight: '0.5rem', width: 'auto' }}
+              />
+              Enable QR code printing
+            </label>
+            <small style={{ color: '#7f8c8d', marginLeft: '1.5rem', display: 'block', marginTop: '0.25rem' }}>
+              When enabled, users can view QR codes on items, print labels, scan QR codes with the camera, and will see the &ldquo;Print Labels&rdquo; prompt after adding items. QR codes are always generated in the background for item lookup regardless of this setting.
             </small>
           </div>
 


### PR DESCRIPTION
Adds a new system setting 'enable_qr_printing' (default: true) that allows admins to toggle all QR/printing UI elements on or off in one place.

When disabled:
- Print Labels nav link is hidden (desktop and mobile)
- SessionBanner (print prompt after adding items) is hidden
- 'Scan QR Code' camera button hidden on desktop inventory and mobile landing
- 'Code' button and QR image hidden on item cards
- QR codes continue to be generated in the background for item lookup

Manual code entry ('Locate Item by Code') and item code success screen remain visible so item lookup/searching is unaffected.

https://claude.ai/code/session_01HwTEc2gQwgjWRQGvMhPY2p