### PR TITLE
Force page reload after saving system settings

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -207,8 +207,7 @@ function Settings({ user, isMobile = false, setUseDesktopInterface }) {
 
     try {
       await settingsAPI.updateSystemSettings(systemSettings);
-      setSystemSuccess('System settings saved successfully');
-      setTimeout(() => setSystemSuccess(''), 3000);
+      window.location.reload();
     } catch (err) {
       setSystemError('Failed to save system settings');
     }


### PR DESCRIPTION
Ensures changes like toggling QR printing take effect immediately without requiring a manual page refresh.

https://claude.ai/code/session_01HwTEc2gQwgjWRQGvMhPY2p