### PR TITLE
Fix duplicate QR checkbox and search-by-code visibility

### DIFF
--- a/frontend/src/pages/Inventory.jsx
+++ b/frontend/src/pages/Inventory.jsx
@@ -306,11 +306,9 @@ function Inventory({ isMobile = false, qrEnabled = true }) {
         </div>
         {!isMobile && (
           <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
-            {qrEnabled && (
-              <button className="btn btn-secondary" onClick={() => setShowQRModal(true)}>
-                🔍 Locate Item by Code
-              </button>
-            )}
+            <button className="btn btn-secondary" onClick={() => setShowQRModal(true)}>
+              🔍 Locate Item by Code
+            </button>
             {qrEnabled && (
               <button className="btn btn-secondary" onClick={() => setShowQRScanner(true)}>
                 📷 Scan QR Code
@@ -441,7 +439,7 @@ function Inventory({ isMobile = false, qrEnabled = true }) {
         />
       )}
 
-      {qrEnabled && showQRModal && (
+      {showQRModal && (
         <QRInputModal
           onClose={() => {
             setShowQRModal(false);

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -661,23 +661,6 @@ function Settings({ user, isMobile = false, setUseDesktopInterface }) {
               <label style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}>
                 <input
                   type="checkbox"
-                  checked={(systemSettings.enable_qr_labels ?? 'true') === 'true'}
-                  onChange={(e) =>
-                    setSystemSettings({ ...systemSettings, enable_qr_labels: e.target.checked ? 'true' : 'false' })
-                  }
-                  style={{ marginRight: '0.5rem', width: 'auto' }}
-                />
-                Enable QR code label printing
-              </label>
-              <small style={{ color: '#7f8c8d', marginLeft: '1.5rem', display: 'block', marginTop: '0.25rem' }}>
-                When enabled, users see QR code buttons on items, the Print Labels page, and the label prompt after adding items. Disable to hide all QR-related UI.
-              </small>
-            </div>
-
-            <div className="form-group" style={{ marginBottom: '1.5rem' }}>
-              <label style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}>
-                <input
-                  type="checkbox"
                   checked={systemSettings.enable_image_fetching === 'true'}
                   onChange={(e) =>
                     setSystemSettings({


### PR DESCRIPTION
- Remove duplicate 'Enable QR code label printing' checkbox in Settings; keep the single 'Enable QR code printing' entry with the accurate description
- Ungate 'Locate Item by Code' button and QRInputModal from qrEnabled so users can still search items by their code when QR label printing is disabled; unique codes are always generated regardless of the QR setting
- Camera QR scanner remains gated on qrEnabled (only useful with printed labels)

https://claude.ai/code/session_01HwTEc2gQwgjWRQGvMhPY2p

Closes #245 
Closes #63 
Closes #40 