### PR TITLE
Fix CI deployment timeout when stopping services

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -29,6 +29,7 @@ jobs:
           username: ${{ secrets.GCP_USERNAME }}
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           envs: UPC_API_KEY,PEXELS_API_KEY
+          command_timeout: 25m
           script: |
             set -e
 
@@ -62,9 +63,11 @@ jobs:
             echo "✓ Code updated"
 
             # Stop services before updating dependencies
+            # Use timeout so a hung service can never block the deployment indefinitely.
+            # If graceful stop takes >30s, force-kill via systemctl kill.
             echo "Stopping services..."
-            sudo systemctl stop freezer-backend-dev
-            sudo systemctl stop freezer-frontend-dev
+            sudo timeout 30 systemctl stop freezer-backend-dev 2>/dev/null || sudo systemctl kill freezer-backend-dev 2>/dev/null || true
+            sudo timeout 30 systemctl stop freezer-frontend-dev 2>/dev/null || sudo systemctl kill freezer-frontend-dev 2>/dev/null || true
             echo "✓ Services stopped"
 
             # Update backend dependencies

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -29,6 +29,7 @@ jobs:
           username: ${{ secrets.GCP_USERNAME }}
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           envs: UPC_API_KEY,PEXELS_API_KEY
+          command_timeout: 25m
           script: |
             set -e
 
@@ -62,9 +63,11 @@ jobs:
             echo "✓ Code updated"
 
             # Stop services before updating dependencies
+            # Use timeout so a hung service can never block the deployment indefinitely.
+            # If graceful stop takes >30s, force-kill via systemctl kill.
             echo "Stopping services..."
-            sudo systemctl stop freezer-backend
-            sudo systemctl stop freezer-frontend
+            sudo timeout 30 systemctl stop freezer-backend 2>/dev/null || sudo systemctl kill freezer-backend 2>/dev/null || true
+            sudo timeout 30 systemctl stop freezer-frontend 2>/dev/null || sudo systemctl kill freezer-frontend 2>/dev/null || true
             echo "✓ Services stopped"
 
             # Update backend dependencies


### PR DESCRIPTION
systemctl stop for the frontend dev service (Vite/npm) can hang indefinitely because npm does not forward SIGTERM to its child processes, causing systemd to wait until TimeoutStopSec is reached. This exhausted the ssh-action default command_timeout of 10 minutes.

- Wrap each systemctl stop with `timeout 30` so it is capped at 30s; fall back to `systemctl kill` (SIGKILL) if the graceful stop stalls.
- Raise command_timeout to 25m in both dev and prod workflows to cover the full deployment pipeline (npm ci now takes longer with recharts).

https://claude.ai/code/session_016C4Af9pbpcSfJTAHtnv9iV