### PR TITLE
Add SSH dial timeout to prevent 29-min handshake hangs and fail2ban bans

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -43,6 +43,10 @@ jobs:
           username: ${{ secrets.GCP_USERNAME }}
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           envs: UPC_API_KEY,PEXELS_API_KEY
+          # timeout: SSH dial+handshake timeout. Fail fast if the server is
+          # unresponsive instead of hanging for 29+ minutes (which previously
+          # triggered fail2ban bans from repeated retry attempts).
+          timeout: 30s
           command_timeout: 10m
           script: |
             set -e
@@ -128,6 +132,7 @@ jobs:
           host: ${{ secrets.GCP_DEV_HOST }}
           username: ${{ secrets.GCP_USERNAME }}
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          timeout: 30s
           command_timeout: 5m
           script: |
             set -e
@@ -184,6 +189,7 @@ jobs:
           host: ${{ secrets.GCP_DEV_HOST }}
           username: ${{ secrets.GCP_USERNAME }}
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          timeout: 30s
           script: |
             echo "======================================"
             echo "✗ GCP Development Deployment Failed!"

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -43,6 +43,7 @@ jobs:
           username: ${{ secrets.GCP_USERNAME }}
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           envs: UPC_API_KEY,PEXELS_API_KEY
+          timeout: 30s
           command_timeout: 10m
           script: |
             set -e
@@ -128,6 +129,7 @@ jobs:
           host: ${{ secrets.GCP_PROD_HOST }}
           username: ${{ secrets.GCP_USERNAME }}
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          timeout: 30s
           command_timeout: 5m
           script: |
             set -e
@@ -184,6 +186,7 @@ jobs:
           host: ${{ secrets.GCP_PROD_HOST }}
           username: ${{ secrets.GCP_USERNAME }}
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          timeout: 30s
           script: |
             echo "======================================"
             echo "✗ GCP Production Deployment Failed!"


### PR DESCRIPTION
When the server was overloaded (orphaned vite process from previous run), the SSH handshake was not timing out -- it hung for ~29 minutes until the vite process finished. During those 29 minutes, drone-ssh repeatedly retried the connection, eventually triggering fail2ban to ban the runner IP (causing the subsequent 'connection reset by peer' on the Notify step).

Add timeout: 30s (SSH dial + handshake timeout) to all SSH action steps. With this set, if the server can't complete an SSH handshake in 30 seconds the step fails immediately rather than hanging, preventing both the long wait and the fail2ban trigger.

https://claude.ai/code/session_016C4Af9pbpcSfJTAHtnv9iV