### PR TITLE
Fix Code button hidden when QR printing is disabled (#264)

### DIFF
--- a/frontend/src/components/ItemCard.jsx
+++ b/frontend/src/components/ItemCard.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { itemsAPI } from '../services/api';
 import { formatLocalDate, daysBetween } from '../utils/dateUtils';
 
-function ItemCard({ item, onEdit, onStatusChange, qrEnabled = true }) {
+function ItemCard({ item, onEdit, onStatusChange }) {
   const [showQR, setShowQR] = useState(false);
 
   const getStatusClass = () => {
@@ -115,15 +115,13 @@ function ItemCard({ item, onEdit, onStatusChange, qrEnabled = true }) {
       </div>
 
       <div className="item-actions">
-        {qrEnabled && (
-          <button
-            className="btn btn-secondary"
-            onClick={() => setShowQR(!showQR)}
-            style={{ flex: 0.5 }}
-          >
-            Code
-          </button>
-        )}
+        <button
+          className="btn btn-secondary"
+          onClick={() => setShowQR(!showQR)}
+          style={{ flex: 0.5 }}
+        >
+          Code
+        </button>
         <button
           className="btn btn-primary"
           onClick={onEdit}
@@ -156,7 +154,7 @@ function ItemCard({ item, onEdit, onStatusChange, qrEnabled = true }) {
         )}
       </div>
 
-      {qrEnabled && showQR && (
+      {showQR && (
         <div className="qr-code-display">
           <p style={{ marginBottom: '0.5rem', fontWeight: 'bold' }}>
             {item.qr_code}

--- a/frontend/src/pages/Inventory.jsx
+++ b/frontend/src/pages/Inventory.jsx
@@ -415,7 +415,6 @@ function Inventory({ isMobile = false, qrEnabled = true }) {
               item={item}
               onEdit={() => handleEditItem(item)}
               onStatusChange={(status) => handleStatusChange(item.id, status)}
-              qrEnabled={qrEnabled}
             />
           ))}
         </div>


### PR DESCRIPTION
The Code button on item cards was gated by the qrEnabled flag, which reflects whether QR label printing is enabled. These are separate concerns — items always have QR codes, so the Code button should always be visible regardless of the print labels setting.

Remove the qrEnabled guard from the Code button and QR display in ItemCard, and drop the now-unused qrEnabled prop from ItemCard.

https://claude.ai/code/session_016C4Af9pbpcSfJTAHtnv9iV

Addresses #264 