### PR TITLE
Hide QR image when printing is disabled, always show alphanumeric cod…

### DIFF
--- a/frontend/src/components/ItemCard.jsx
+++ b/frontend/src/components/ItemCard.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { itemsAPI } from '../services/api';
 import { formatLocalDate, daysBetween } from '../utils/dateUtils';
 
-function ItemCard({ item, onEdit, onStatusChange }) {
+function ItemCard({ item, onEdit, onStatusChange, qrEnabled = true }) {
   const [showQR, setShowQR] = useState(false);
 
   const getStatusClass = () => {
@@ -159,13 +159,17 @@ function ItemCard({ item, onEdit, onStatusChange }) {
           <p style={{ marginBottom: '0.5rem', fontWeight: 'bold' }}>
             {item.qr_code}
           </p>
-          <img
-            src={itemsAPI.getQRImage(item.qr_code)}
-            alt={`QR Code for ${item.name}`}
-          />
-          <p style={{ marginTop: '0.5rem', fontSize: '0.875rem', color: '#7f8c8d' }}>
-            Write this code on your bag or scan the QR code to quickly access this item
-          </p>
+          {qrEnabled && (
+            <>
+              <img
+                src={itemsAPI.getQRImage(item.qr_code)}
+                alt={`QR Code for ${item.name}`}
+              />
+              <p style={{ marginTop: '0.5rem', fontSize: '0.875rem', color: '#7f8c8d' }}>
+                Write this code on your bag or scan the QR code to quickly access this item
+              </p>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/pages/Inventory.jsx
+++ b/frontend/src/pages/Inventory.jsx
@@ -415,6 +415,7 @@ function Inventory({ isMobile = false, qrEnabled = true }) {
               item={item}
               onEdit={() => handleEditItem(item)}
               onStatusChange={(status) => handleStatusChange(item.id, status)}
+              qrEnabled={qrEnabled}
             />
           ))}
         </div>


### PR DESCRIPTION
…e (#264)

When QR label printing is disabled, the Code button now shows only the item's unique alphanumeric code. The QR image and scan hint text are hidden since they're only relevant when printing/scanning is in use.

https://claude.ai/code/session_016C4Af9pbpcSfJTAHtnv9iV