### PR TITLE
fix: add curl --max-time to prevent health check hanging on deploy

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -145,7 +145,7 @@ jobs:
             # Backend health check (retry up to 30 seconds)
             echo "Running health check..."
             for i in {1..6}; do
-              if curl -f http://localhost:5002/api/health > /dev/null 2>&1; then
+              if curl -f --max-time 5 http://localhost:5002/api/health > /dev/null 2>&1; then
                 echo "✓ Backend health check passed"
                 break
               fi
@@ -160,7 +160,7 @@ jobs:
 
             # Frontend health check (retry up to 30 seconds)
             for i in {1..6}; do
-              if curl -f http://localhost:3001 > /dev/null 2>&1; then
+              if curl -f --max-time 5 http://localhost:3001 > /dev/null 2>&1; then
                 echo "✓ Frontend health check passed"
                 break
               fi

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -142,7 +142,7 @@ jobs:
             # Backend health check (retry up to 30 seconds)
             echo "Running health check..."
             for i in {1..6}; do
-              if curl -f http://localhost:5001/api/health > /dev/null 2>&1; then
+              if curl -f --max-time 5 http://localhost:5001/api/health > /dev/null 2>&1; then
                 echo "✓ Backend health check passed"
                 break
               fi
@@ -157,7 +157,7 @@ jobs:
 
             # Frontend health check (retry up to 30 seconds)
             for i in {1..6}; do
-              if curl -f http://localhost:3000 > /dev/null 2>&1; then
+              if curl -f --max-time 5 http://localhost:3000 > /dev/null 2>&1; then
                 echo "✓ Frontend health check passed"
                 break
               fi


### PR DESCRIPTION
Without a timeout, curl blocks indefinitely if the service is slow to respond, causing the 5m command_timeout to be hit. Adding --max-time 5 ensures each probe fails fast and the retry loop behaves as intended.

https://claude.ai/code/session_016C4Af9pbpcSfJTAHtnv9iV