### PR TITLE
Fix potential startup crash if resend package unavailable

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -159,6 +159,8 @@ jobs:
               if [ $i -eq 6 ]; then
                 echo "✗ Backend health check failed after 30s!"
                 sudo systemctl status freezer-backend-dev --no-pager
+                echo "--- Recent logs ---"
+                sudo journalctl -u freezer-backend-dev -n 50 --no-pager
                 exit 1
               fi
               echo "  Waiting for backend... (attempt $i/6)"

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -156,6 +156,8 @@ jobs:
               if [ $i -eq 6 ]; then
                 echo "✗ Backend health check failed after 30s!"
                 sudo systemctl status freezer-backend --no-pager
+                echo "--- Recent logs ---"
+                sudo journalctl -u freezer-backend -n 50 --no-pager
                 exit 1
               fi
               echo "  Waiting for backend... (attempt $i/6)"

--- a/backend/utils/email.py
+++ b/backend/utils/email.py
@@ -11,9 +11,15 @@ Optional:
 
 import os
 import logging
-import resend
 
 logger = logging.getLogger(__name__)
+
+try:
+    import resend
+    _RESEND_AVAILABLE = True
+except ImportError:
+    resend = None  # type: ignore[assignment]
+    _RESEND_AVAILABLE = False
 
 
 def _get_config():
@@ -48,6 +54,8 @@ def send_email(to_addresses, subject, text_body, html_body=None):
     """
     cfg = _get_config()
 
+    if not _RESEND_AVAILABLE:
+        raise RuntimeError('resend package is not installed. Run: pip install "resend>=2.0.0"')
     if not cfg['api_key']:
         raise RuntimeError('RESEND_API_KEY is not configured')
     if not cfg['from_address']:


### PR DESCRIPTION
Guard the top-level `import resend` with a try/except so the app can start (and pass health checks) even if the package fails to import. Also add journalctl output to health check failure output to make future failures easier to diagnose.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH