### PR TITLE
Add low-stock email alerts and a dedicated Notifications page (#236)

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -140,6 +140,35 @@ class Setting(db.Model):
         }
 
 
+class LowStockAlert(db.Model):
+    __tablename__ = 'low_stock_alerts'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    item_name = db.Column(db.String(200), nullable=False)
+    threshold = db.Column(db.Integer, nullable=False, default=2)
+    enabled = db.Column(db.Boolean, default=True)
+    last_sent_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship('User', backref='low_stock_alerts')
+
+    __table_args__ = (
+        db.UniqueConstraint('user_id', 'item_name', name='_user_item_alert_uc'),
+    )
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'user_id': self.user_id,
+            'item_name': self.item_name,
+            'threshold': self.threshold,
+            'enabled': self.enabled,
+            'last_sent_at': self.last_sent_at.isoformat() if self.last_sent_at else None,
+            'created_at': self.created_at.isoformat(),
+        }
+
+
 def generate_qr_code():
     """Generate a unique alphanumeric code identifier (e.g., ABC123)"""
     import random

--- a/backend/routes/items.py
+++ b/backend/routes/items.py
@@ -470,15 +470,25 @@ def update_item(item_id):
         item.expiration_date = datetime.fromisoformat(data['expiration_date']) if data['expiration_date'] else None
     if 'notes' in data:
         item.notes = data['notes']
+    new_status = None
     if 'status' in data:
         # Validate status
         if data['status'] not in ['in_freezer', 'consumed', 'thrown_out']:
             return jsonify({'error': 'Invalid status'}), 400
-        item.status = data['status']
+        new_status = data['status']
+        item.status = new_status
     if 'removed_date' in data:
         item.removed_date = datetime.fromisoformat(data['removed_date']) if data['removed_date'] else None
 
+    item_name_for_alert = item.name
     db.session.commit()
+
+    if new_status in ['consumed', 'thrown_out']:
+        try:
+            from routes.notifications import check_and_send_low_stock_alerts
+            check_and_send_low_stock_alerts(item_name_for_alert)
+        except Exception:
+            pass
 
     return jsonify(item.to_dict()), 200
 
@@ -505,7 +515,15 @@ def update_item_status(item_id):
     else:
         item.removed_date = None
 
+    item_name_for_alert = item.name
     db.session.commit()
+
+    if new_status in ['consumed', 'thrown_out']:
+        try:
+            from routes.notifications import check_and_send_low_stock_alerts
+            check_and_send_low_stock_alerts(item_name_for_alert)
+        except Exception:
+            pass
 
     return jsonify(item.to_dict()), 200
 

--- a/backend/routes/notifications.py
+++ b/backend/routes/notifications.py
@@ -8,6 +8,11 @@ Routes (all require JWT):
   PUT  /api/notifications/email/me                – update current user's notification email
   POST /api/notifications/email/verify            – verify the 6-digit code
   POST /api/notifications/email/resend-verification – resend verification code
+
+  GET    /api/notifications/low-stock             – list current user's low-stock alerts
+  POST   /api/notifications/low-stock             – create a low-stock alert
+  PUT    /api/notifications/low-stock/<id>        – update threshold / enabled
+  DELETE /api/notifications/low-stock/<id>        – delete an alert
 """
 
 import logging
@@ -17,7 +22,8 @@ from datetime import datetime, timedelta
 
 from flask import Blueprint, request, jsonify
 from flask_jwt_extended import jwt_required, get_jwt_identity, get_jwt
-from models import db, User
+from sqlalchemy import func
+from models import db, User, Item, LowStockAlert
 from utils.email import is_email_configured, send_email, send_verification_email
 
 notifications_bp = Blueprint('notifications', __name__)
@@ -248,3 +254,149 @@ def resend_verification():
         return jsonify({'error': 'Failed to send verification email. Check server logs.'}), 500
 
     return jsonify({'message': f'Verification code resent to {user.email}'}), 200
+
+
+# ── Low-stock alerts ──────────────────────────────────────────────────────────
+
+_LOW_STOCK_COOLDOWN_HOURS = 24
+
+
+def _send_low_stock_email(to_address, item_name, current_count, threshold):
+    """Send a low-stock alert email."""
+    subject = f'Low stock alert – {item_name}'
+    qty = f'{current_count} item{"" if current_count == 1 else "s"}'
+    text = (
+        f'Low stock alert for "{item_name}".\n\n'
+        f'You have {qty} remaining in your freezer '
+        f'(alert threshold: {threshold}).\n\n'
+        'Time to restock!'
+    )
+    html = (
+        f'<p>Low stock alert for <strong>{item_name}</strong>.</p>'
+        f'<p>You have <strong>{qty}</strong> remaining in your freezer '
+        f'(alert threshold: {threshold}).</p>'
+        '<p>Time to restock!</p>'
+    )
+    send_email(to_addresses=to_address, subject=subject, text_body=text, html_body=html)
+
+
+def check_and_send_low_stock_alerts(item_name):
+    """Check all low-stock alerts for item_name and fire emails as needed.
+
+    Called after an item's status changes to consumed/thrown_out.
+    """
+    if not is_email_configured():
+        return
+
+    current_count = Item.query.filter(
+        func.lower(Item.name) == item_name.lower(),
+        Item.status == 'in_freezer',
+    ).count()
+
+    alerts = LowStockAlert.query.filter(
+        func.lower(LowStockAlert.item_name) == item_name.lower(),
+        LowStockAlert.enabled == True,
+        LowStockAlert.threshold >= current_count,
+    ).all()
+
+    for alert in alerts:
+        # Respect cooldown to avoid email spam
+        if alert.last_sent_at:
+            hours_since = (datetime.utcnow() - alert.last_sent_at).total_seconds() / 3600
+            if hours_since < _LOW_STOCK_COOLDOWN_HOURS:
+                continue
+
+        user = alert.user
+        if not user or not user.email or not user.email_verified:
+            continue
+
+        try:
+            _send_low_stock_email(user.email, item_name, current_count, alert.threshold)
+            alert.last_sent_at = datetime.utcnow()
+            db.session.commit()
+        except RuntimeError:
+            logging.exception('Failed to send low-stock alert for "%s" to %s', item_name, user.email)
+
+
+@notifications_bp.route('/low-stock', methods=['GET'])
+@jwt_required()
+def list_low_stock_alerts():
+    """Return all low-stock alerts for the current user."""
+    current_user_id = int(get_jwt_identity())
+    alerts = LowStockAlert.query.filter_by(user_id=current_user_id).order_by(LowStockAlert.item_name).all()
+    return jsonify([a.to_dict() for a in alerts]), 200
+
+
+@notifications_bp.route('/low-stock', methods=['POST'])
+@jwt_required()
+def create_low_stock_alert():
+    """Create a new low-stock alert for the current user."""
+    current_user_id = int(get_jwt_identity())
+    data = request.get_json()
+    if not data:
+        return jsonify({'error': 'Request body required'}), 400
+
+    item_name = (data.get('item_name') or '').strip()
+    if not item_name:
+        return jsonify({'error': 'item_name is required'}), 400
+
+    threshold = data.get('threshold', 2)
+    try:
+        threshold = int(threshold)
+        if threshold < 1:
+            raise ValueError
+    except (TypeError, ValueError):
+        return jsonify({'error': 'threshold must be a positive integer'}), 400
+
+    existing = LowStockAlert.query.filter(
+        LowStockAlert.user_id == current_user_id,
+        func.lower(LowStockAlert.item_name) == item_name.lower(),
+    ).first()
+    if existing:
+        return jsonify({'error': f'An alert for "{item_name}" already exists'}), 409
+
+    alert = LowStockAlert(user_id=current_user_id, item_name=item_name, threshold=threshold)
+    db.session.add(alert)
+    db.session.commit()
+    return jsonify(alert.to_dict()), 201
+
+
+@notifications_bp.route('/low-stock/<int:alert_id>', methods=['PUT'])
+@jwt_required()
+def update_low_stock_alert(alert_id):
+    """Update threshold and/or enabled flag for an alert."""
+    current_user_id = int(get_jwt_identity())
+    alert = LowStockAlert.query.filter_by(id=alert_id, user_id=current_user_id).first()
+    if not alert:
+        return jsonify({'error': 'Alert not found'}), 404
+
+    data = request.get_json() or {}
+
+    if 'threshold' in data:
+        try:
+            threshold = int(data['threshold'])
+            if threshold < 1:
+                raise ValueError
+            alert.threshold = threshold
+        except (TypeError, ValueError):
+            return jsonify({'error': 'threshold must be a positive integer'}), 400
+
+    if 'enabled' in data:
+        alert.enabled = bool(data['enabled'])
+
+    db.session.commit()
+    return jsonify(alert.to_dict()), 200
+
+
+@notifications_bp.route('/low-stock/<int:alert_id>', methods=['DELETE'])
+@jwt_required()
+def delete_low_stock_alert(alert_id):
+    """Delete a low-stock alert."""
+    current_user_id = int(get_jwt_identity())
+    alert = LowStockAlert.query.filter_by(id=alert_id, user_id=current_user_id).first()
+    if not alert:
+        return jsonify({'error': 'Alert not found'}), 404
+
+    db.session.delete(alert)
+    db.session.commit()
+    return jsonify({'message': 'Alert deleted'}), 200

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,7 @@ const Settings = lazy(() => import('./pages/Settings'));
 const QRRedirect = lazy(() => import('./pages/QRRedirect'));
 const MobileLanding = lazy(() => import('./pages/MobileLanding'));
 const Dashboard = lazy(() => import('./pages/Dashboard'));
+const EmailNotifications = lazy(() => import('./pages/EmailNotifications'));
 const InstallPrompt = lazy(() => import('./components/InstallPrompt'));
 
 function AppContent() {
@@ -175,6 +176,7 @@ function AppContent() {
                         {qrEnabled && <Link to="/print-labels" onClick={() => setMobileMenuOpen(false)}>Print Labels</Link>}
                       </div>
                     </details>
+                    <Link to="/notifications" onClick={() => setMobileMenuOpen(false)}>Notifications</Link>
                     <Link to="/settings" className="navbar-settings-link" onClick={() => setMobileMenuOpen(false)}>⚙️ Settings</Link>
                   </div>
                 ) : (
@@ -184,6 +186,7 @@ function AppContent() {
                     <Link to="/dashboard" onClick={() => setMobileMenuOpen(false)}>Statistics</Link>
                     <Link to="/categories" onClick={() => setMobileMenuOpen(false)}>Categories</Link>
                     {qrEnabled && <Link to="/print-labels" onClick={() => setMobileMenuOpen(false)}>Print Labels</Link>}
+                    <Link to="/notifications" onClick={() => setMobileMenuOpen(false)}>Notifications</Link>
                     <Link to="/settings" onClick={() => setMobileMenuOpen(false)}>Settings</Link>
                   </>
                 )}
@@ -209,6 +212,7 @@ function AppContent() {
                   <Route path="/dashboard" element={<Dashboard />} />
                   <Route path="/categories" element={<Categories />} />
                   <Route path="/print-labels" element={<PrintLabels />} />
+                  <Route path="/notifications" element={<EmailNotifications />} />
                   <Route path="/settings" element={<Settings user={user} isMobile={true} setUseDesktopInterface={setUseDesktopInterface} />} />
                   <Route path="*" element={<Navigate to="/home" />} />
                 </>
@@ -220,6 +224,7 @@ function AppContent() {
                   <Route path="/dashboard" element={<Dashboard />} />
                   <Route path="/categories" element={<Categories />} />
                   <Route path="/print-labels" element={<PrintLabels />} />
+                  <Route path="/notifications" element={<EmailNotifications />} />
                   <Route path="/settings" element={<Settings user={user} />} />
                   <Route path="*" element={<Navigate to="/" />} />
                 </>

--- a/frontend/src/pages/EmailNotifications.jsx
+++ b/frontend/src/pages/EmailNotifications.jsx
@@ -1,0 +1,528 @@
+import { useState, useEffect, useRef } from 'react';
+import { notificationsAPI, itemsAPI } from '../services/api';
+
+function EmailNotifications() {
+  // ── Email address state ────────────────────────────────────────────────────
+  const [emailConfigured, setEmailConfigured] = useState(false);
+  const [myEmail, setMyEmail] = useState('');
+  const [myEmailVerified, setMyEmailVerified] = useState(false);
+  const [emailInput, setEmailInput] = useState('');
+  const [emailError, setEmailError] = useState('');
+  const [emailSuccess, setEmailSuccess] = useState('');
+  const [emailLoading, setEmailLoading] = useState(false);
+
+  const [verificationCode, setVerificationCode] = useState('');
+  const [verifyError, setVerifyError] = useState('');
+  const [verifySuccess, setVerifySuccess] = useState('');
+  const [verifyLoading, setVerifyLoading] = useState(false);
+
+  const [testEmailError, setTestEmailError] = useState('');
+  const [testEmailSuccess, setTestEmailSuccess] = useState('');
+  const [testEmailLoading, setTestEmailLoading] = useState(false);
+
+  // ── Low-stock alerts state ─────────────────────────────────────────────────
+  const [alerts, setAlerts] = useState([]);
+  const [alertsLoading, setAlertsLoading] = useState(true);
+  const [alertsError, setAlertsError] = useState('');
+
+  // Add-alert form
+  const [newItemName, setNewItemName] = useState('');
+  const [newThreshold, setNewThreshold] = useState(2);
+  const [addError, setAddError] = useState('');
+  const [addLoading, setAddLoading] = useState(false);
+
+  // Autocomplete for item name
+  const [itemNameSuggestions, setItemNameSuggestions] = useState([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const suggestionRef = useRef(null);
+
+  // ── Load on mount ──────────────────────────────────────────────────────────
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [statusRes, emailRes] = await Promise.all([
+          notificationsAPI.getStatus(),
+          notificationsAPI.getMyEmail(),
+        ]);
+        setEmailConfigured(statusRes.data.configured);
+        setMyEmail(emailRes.data.email || '');
+        setEmailInput(emailRes.data.email || '');
+        setMyEmailVerified(emailRes.data.email_verified || false);
+      } catch {
+        // non-critical
+      }
+
+      try {
+        const res = await notificationsAPI.getLowStockAlerts();
+        setAlerts(res.data);
+      } catch {
+        setAlertsError('Failed to load alerts.');
+      } finally {
+        setAlertsLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  // Close suggestions on outside click
+  useEffect(() => {
+    const handler = (e) => {
+      if (suggestionRef.current && !suggestionRef.current.contains(e.target)) {
+        setShowSuggestions(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  // ── Email address handlers ─────────────────────────────────────────────────
+  const handleSaveEmail = async () => {
+    setEmailError('');
+    setEmailSuccess('');
+    setEmailLoading(true);
+    try {
+      const res = await notificationsAPI.updateMyEmail(emailInput.trim());
+      setMyEmail(res.data.email || '');
+      setMyEmailVerified(res.data.email_verified || false);
+      setVerificationCode('');
+      setVerifyError('');
+      setVerifySuccess('');
+      if (res.data.verification_required) {
+        setEmailSuccess(`Verification code sent to ${res.data.email}`);
+      } else if (!res.data.email) {
+        setEmailSuccess('Email removed.');
+      } else {
+        setEmailSuccess('Email already verified.');
+      }
+    } catch (err) {
+      setEmailError(err.response?.data?.error || 'Failed to save email.');
+    } finally {
+      setEmailLoading(false);
+    }
+  };
+
+  const handleVerifyCode = async () => {
+    setVerifyError('');
+    setVerifySuccess('');
+    setVerifyLoading(true);
+    try {
+      await notificationsAPI.verifyEmail(verificationCode.trim());
+      setMyEmailVerified(true);
+      setVerifySuccess('Email verified!');
+      setVerificationCode('');
+    } catch (err) {
+      setVerifyError(err.response?.data?.error || 'Verification failed.');
+    } finally {
+      setVerifyLoading(false);
+    }
+  };
+
+  const handleResendCode = async () => {
+    setVerifyError('');
+    setVerifySuccess('');
+    try {
+      await notificationsAPI.resendVerification();
+      setVerifySuccess(`New code sent to ${myEmail}`);
+    } catch (err) {
+      setVerifyError(err.response?.data?.error || 'Failed to resend code.');
+    }
+  };
+
+  const handleSendTestEmail = async () => {
+    setTestEmailError('');
+    setTestEmailSuccess('');
+    setTestEmailLoading(true);
+    try {
+      const res = await notificationsAPI.sendTestEmail();
+      setTestEmailSuccess(res.data.message || 'Test email sent!');
+    } catch (err) {
+      setTestEmailError(err.response?.data?.error || 'Failed to send test email.');
+    } finally {
+      setTestEmailLoading(false);
+    }
+  };
+
+  // ── Autocomplete helpers ───────────────────────────────────────────────────
+  const handleItemNameChange = async (value) => {
+    setNewItemName(value);
+    if (value.trim().length < 1) {
+      setItemNameSuggestions([]);
+      setShowSuggestions(false);
+      return;
+    }
+    try {
+      const res = await itemsAPI.getItems({ status: 'in_freezer' });
+      const items = res.data.items || res.data || [];
+      const lower = value.toLowerCase();
+      const unique = [...new Set(
+        items
+          .map(i => i.name)
+          .filter(n => n.toLowerCase().includes(lower))
+      )].slice(0, 8);
+      setItemNameSuggestions(unique);
+      setShowSuggestions(unique.length > 0);
+    } catch {
+      setItemNameSuggestions([]);
+    }
+  };
+
+  // ── Low-stock alert handlers ───────────────────────────────────────────────
+  const handleAddAlert = async () => {
+    setAddError('');
+    const name = newItemName.trim();
+    if (!name) { setAddError('Item name is required.'); return; }
+    if (!Number.isInteger(Number(newThreshold)) || Number(newThreshold) < 1) {
+      setAddError('Threshold must be a positive number.'); return;
+    }
+    setAddLoading(true);
+    try {
+      const res = await notificationsAPI.createLowStockAlert(name, Number(newThreshold));
+      setAlerts(prev => [...prev, res.data].sort((a, b) => a.item_name.localeCompare(b.item_name)));
+      setNewItemName('');
+      setNewThreshold(2);
+    } catch (err) {
+      setAddError(err.response?.data?.error || 'Failed to create alert.');
+    } finally {
+      setAddLoading(false);
+    }
+  };
+
+  const handleToggleEnabled = async (alert) => {
+    try {
+      const res = await notificationsAPI.updateLowStockAlert(alert.id, { enabled: !alert.enabled });
+      setAlerts(prev => prev.map(a => a.id === alert.id ? res.data : a));
+    } catch {
+      setAlertsError('Failed to update alert.');
+    }
+  };
+
+  const handleThresholdChange = async (alert, value) => {
+    const threshold = parseInt(value, 10);
+    if (!threshold || threshold < 1) return;
+    try {
+      const res = await notificationsAPI.updateLowStockAlert(alert.id, { threshold });
+      setAlerts(prev => prev.map(a => a.id === alert.id ? res.data : a));
+    } catch {
+      setAlertsError('Failed to update threshold.');
+    }
+  };
+
+  const handleDeleteAlert = async (id) => {
+    try {
+      await notificationsAPI.deleteLowStockAlert(id);
+      setAlerts(prev => prev.filter(a => a.id !== id));
+    } catch {
+      setAlertsError('Failed to delete alert.');
+    }
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  return (
+    <div className="page-container" style={{ maxWidth: '700px', margin: '0 auto', padding: '2rem 1rem' }}>
+      <h2 style={{ margin: '0 0 0.25rem' }}>Email Notifications</h2>
+      <p style={{ color: '#6c757d', margin: '0 0 2rem', fontSize: '0.95rem' }}>
+        Manage your notification email address and low-stock alerts.
+      </p>
+
+      {/* ── Email address section ────────────────────────────────────────── */}
+      <section style={sectionStyle}>
+        <h3 style={sectionHeadingStyle}>Notification email address</h3>
+
+        {!emailConfigured && (
+          <div style={warningBannerStyle}>
+            Email notifications are not configured on this server. Contact your administrator.
+          </div>
+        )}
+
+        {emailError && <div className="error-message" style={{ marginBottom: '0.75rem' }}>{emailError}</div>}
+        {emailSuccess && <div className="success-message" style={{ marginBottom: '0.75rem' }}>{emailSuccess}</div>}
+
+        <p style={{ margin: '0 0 0.75rem', fontSize: '0.875rem', color: '#7f8c8d' }}>
+          Notifications will be sent to this address. It must be verified before alerts fire.
+        </p>
+
+        {myEmail && (
+          <div style={{ marginBottom: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <span style={{ fontSize: '0.9rem', color: '#495057' }}>{myEmail}</span>
+            {myEmailVerified ? (
+              <span style={verifiedBadgeStyle}>Verified</span>
+            ) : (
+              <span style={unverifiedBadgeStyle}>Not verified</span>
+            )}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <input
+            type="email"
+            value={emailInput}
+            onChange={(e) => setEmailInput(e.target.value)}
+            placeholder="you@example.com"
+            style={{ flex: 1 }}
+            disabled={!emailConfigured}
+          />
+          <button className="btn btn-primary" onClick={handleSaveEmail} disabled={emailLoading || !emailConfigured}>
+            {emailLoading ? 'Saving…' : 'Save'}
+          </button>
+          {myEmail && (
+            <button
+              className="btn btn-secondary"
+              onClick={() => setEmailInput('')}
+              disabled={emailLoading || !emailConfigured}
+            >
+              Clear
+            </button>
+          )}
+        </div>
+
+        {/* Verification code entry */}
+        {myEmail && !myEmailVerified && (
+          <div style={{ marginTop: '1.25rem', padding: '1rem', background: '#f8f9fa', border: '1px solid #e9ecef', borderRadius: '6px' }}>
+            <h4 style={{ margin: '0 0 0.75rem', fontSize: '0.95rem' }}>Verify your email</h4>
+            <p style={{ margin: '0 0 0.75rem', fontSize: '0.875rem', color: '#7f8c8d' }}>
+              Enter the 6-digit code sent to <strong>{myEmail}</strong>.
+            </p>
+            {verifyError && <div className="error-message" style={{ marginBottom: '0.75rem' }}>{verifyError}</div>}
+            {verifySuccess && <div className="success-message" style={{ marginBottom: '0.75rem' }}>{verifySuccess}</div>}
+            <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+              <input
+                type="text"
+                value={verificationCode}
+                onChange={(e) => setVerificationCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                placeholder="123456"
+                maxLength={6}
+                style={{ width: '8rem', fontFamily: 'monospace', fontSize: '1.25rem', letterSpacing: '0.2em', textAlign: 'center' }}
+              />
+              <button className="btn btn-primary" onClick={handleVerifyCode} disabled={verifyLoading || verificationCode.length !== 6}>
+                {verifyLoading ? 'Verifying…' : 'Verify'}
+              </button>
+              <button className="btn btn-secondary" onClick={handleResendCode} style={{ fontSize: '0.85rem' }}>
+                Resend code
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Test email */}
+        {emailConfigured && (
+          <div style={{ marginTop: '1.25rem', paddingTop: '1.25rem', borderTop: '1px solid #e9ecef' }}>
+            <h4 style={{ margin: '0 0 0.5rem', fontSize: '0.95rem' }}>Send test email</h4>
+            <p style={{ margin: '0 0 0.75rem', fontSize: '0.875rem', color: '#7f8c8d' }}>
+              Verify Resend is configured correctly. The test email will be sent to your verified address.
+            </p>
+            {testEmailError && <div className="error-message" style={{ marginBottom: '0.75rem' }}>{testEmailError}</div>}
+            {testEmailSuccess && <div className="success-message" style={{ marginBottom: '0.75rem' }}>{testEmailSuccess}</div>}
+            <button className="btn btn-secondary" onClick={handleSendTestEmail} disabled={testEmailLoading || !myEmailVerified}>
+              {testEmailLoading ? 'Sending…' : 'Send Test Email'}
+            </button>
+            {!myEmailVerified && (
+              <small style={{ color: '#856404', marginLeft: '0.75rem' }}>
+                Verify your email address above to enable this.
+              </small>
+            )}
+          </div>
+        )}
+      </section>
+
+      {/* ── Low-stock alerts section ──────────────────────────────────────── */}
+      <section style={{ ...sectionStyle, marginTop: '1.5rem' }}>
+        <h3 style={sectionHeadingStyle}>Low stock alerts</h3>
+        <p style={{ margin: '0 0 1rem', fontSize: '0.875rem', color: '#7f8c8d' }}>
+          Get an email when an item in your freezer falls to or below your chosen quantity.
+          {!myEmailVerified && (
+            <span style={{ color: '#856404' }}> (Add a verified email above to receive alerts.)</span>
+          )}
+        </p>
+
+        {alertsError && <div className="error-message" style={{ marginBottom: '0.75rem' }}>{alertsError}</div>}
+
+        {/* Add alert form */}
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'flex-end', flexWrap: 'wrap', marginBottom: '1.25rem' }}>
+          <div style={{ flex: '1 1 200px', position: 'relative' }} ref={suggestionRef}>
+            <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: '#495057' }}>
+              Item name
+            </label>
+            <input
+              type="text"
+              value={newItemName}
+              onChange={(e) => handleItemNameChange(e.target.value)}
+              onFocus={() => itemNameSuggestions.length > 0 && setShowSuggestions(true)}
+              placeholder="e.g. Puppy Chicken"
+              style={{ width: '100%', boxSizing: 'border-box' }}
+            />
+            {showSuggestions && (
+              <ul style={suggestionsStyle}>
+                {itemNameSuggestions.map(name => (
+                  <li
+                    key={name}
+                    onMouseDown={() => { setNewItemName(name); setShowSuggestions(false); }}
+                    style={suggestionItemStyle}
+                    onMouseEnter={(e) => e.currentTarget.style.background = '#f0f4ff'}
+                    onMouseLeave={(e) => e.currentTarget.style.background = 'white'}
+                  >
+                    {name}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          <div style={{ width: '110px' }}>
+            <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: '#495057' }}>
+              Alert when ≤
+            </label>
+            <input
+              type="number"
+              value={newThreshold}
+              onChange={(e) => setNewThreshold(e.target.value)}
+              min={1}
+              style={{ width: '100%', boxSizing: 'border-box' }}
+            />
+          </div>
+          <button
+            className="btn btn-primary"
+            onClick={handleAddAlert}
+            disabled={addLoading}
+            style={{ alignSelf: 'flex-end' }}
+          >
+            {addLoading ? 'Adding…' : 'Add alert'}
+          </button>
+        </div>
+        {addError && <div className="error-message" style={{ marginBottom: '0.75rem' }}>{addError}</div>}
+
+        {/* Alert list */}
+        {alertsLoading ? (
+          <p style={{ color: '#7f8c8d', fontSize: '0.9rem' }}>Loading alerts…</p>
+        ) : alerts.length === 0 ? (
+          <p style={{ color: '#7f8c8d', fontSize: '0.9rem', fontStyle: 'italic' }}>
+            No low-stock alerts yet.
+          </p>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
+            <thead>
+              <tr style={{ borderBottom: '2px solid #e9ecef', textAlign: 'left' }}>
+                <th style={thStyle}>Item</th>
+                <th style={{ ...thStyle, width: '120px' }}>Alert when ≤</th>
+                <th style={{ ...thStyle, width: '80px' }}>Enabled</th>
+                <th style={{ ...thStyle, width: '60px' }}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {alerts.map(alert => (
+                <tr key={alert.id} style={{ borderBottom: '1px solid #f0f0f0' }}>
+                  <td style={tdStyle}>{alert.item_name}</td>
+                  <td style={tdStyle}>
+                    <input
+                      type="number"
+                      defaultValue={alert.threshold}
+                      min={1}
+                      onBlur={(e) => handleThresholdChange(alert, e.target.value)}
+                      style={{ width: '70px', padding: '0.25rem 0.4rem', border: '1px solid #ced4da', borderRadius: '4px' }}
+                    />
+                  </td>
+                  <td style={tdStyle}>
+                    <input
+                      type="checkbox"
+                      checked={alert.enabled}
+                      onChange={() => handleToggleEnabled(alert)}
+                      style={{ cursor: 'pointer', width: '16px', height: '16px' }}
+                    />
+                  </td>
+                  <td style={tdStyle}>
+                    <button
+                      onClick={() => handleDeleteAlert(alert.id)}
+                      style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#dc3545', fontSize: '1rem', padding: '0.2rem 0.4rem' }}
+                      title="Delete alert"
+                    >
+                      ✕
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+}
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+const sectionStyle = {
+  background: 'white',
+  borderRadius: '8px',
+  border: '1px solid #e9ecef',
+  padding: '1.5rem',
+};
+
+const sectionHeadingStyle = {
+  margin: '0 0 1rem',
+  fontSize: '1.05rem',
+  paddingBottom: '0.75rem',
+  borderBottom: '1px solid #e9ecef',
+};
+
+const warningBannerStyle = {
+  padding: '0.75rem 1rem',
+  background: '#fff3cd',
+  border: '1px solid #ffc107',
+  borderRadius: '4px',
+  marginBottom: '1rem',
+  fontSize: '0.9rem',
+  color: '#856404',
+};
+
+const verifiedBadgeStyle = {
+  fontSize: '0.75rem',
+  background: '#d4edda',
+  color: '#155724',
+  padding: '0.15rem 0.5rem',
+  borderRadius: '3px',
+  fontWeight: '600',
+};
+
+const unverifiedBadgeStyle = {
+  fontSize: '0.75rem',
+  background: '#fff3cd',
+  color: '#856404',
+  padding: '0.15rem 0.5rem',
+  borderRadius: '3px',
+  fontWeight: '600',
+};
+
+const suggestionsStyle = {
+  position: 'absolute',
+  top: '100%',
+  left: 0,
+  right: 0,
+  background: 'white',
+  border: '1px solid #ced4da',
+  borderRadius: '0 0 4px 4px',
+  margin: 0,
+  padding: 0,
+  listStyle: 'none',
+  zIndex: 100,
+  boxShadow: '0 4px 8px rgba(0,0,0,0.1)',
+  maxHeight: '200px',
+  overflowY: 'auto',
+};
+
+const suggestionItemStyle = {
+  padding: '0.5rem 0.75rem',
+  cursor: 'pointer',
+  fontSize: '0.9rem',
+  background: 'white',
+};
+
+const thStyle = {
+  padding: '0.5rem 0.75rem',
+  fontWeight: '600',
+  color: '#495057',
+  fontSize: '0.85rem',
+};
+
+const tdStyle = {
+  padding: '0.6rem 0.75rem',
+  verticalAlign: 'middle',
+};
+
+export default EmailNotifications;

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { settingsAPI, authAPI, notificationsAPI } from '../services/api';
+import { Link } from 'react-router-dom';
+import { settingsAPI, authAPI } from '../services/api';
 import UserManagement from '../components/UserManagement';
 import ImportExport from '../components/ImportExport';
 import FeedbackManagement from '../components/FeedbackManagement';
@@ -100,24 +101,6 @@ function Settings({ user, isMobile = false, setUseDesktopInterface }) {
   const [passkeys, setPasskeys] = useState([]);
   const [passkeysLoading, setPasskeysLoading] = useState(false);
 
-  // Email notification state
-  const [myEmail, setMyEmail] = useState('');
-  const [myEmailVerified, setMyEmailVerified] = useState(false);
-  const [emailInput, setEmailInput] = useState('');
-  const [emailError, setEmailError] = useState('');
-  const [emailSuccess, setEmailSuccess] = useState('');
-  const [emailLoading, setEmailLoading] = useState(false);
-  const [verificationCode, setVerificationCode] = useState('');
-  const [verifyError, setVerifyError] = useState('');
-  const [verifySuccess, setVerifySuccess] = useState('');
-  const [verifyLoading, setVerifyLoading] = useState(false);
-  const [emailConfigured, setEmailConfigured] = useState(false);
-
-  // Test email state
-  const [testEmailError, setTestEmailError] = useState('');
-  const [testEmailSuccess, setTestEmailSuccess] = useState('');
-  const [testEmailLoading, setTestEmailLoading] = useState(false);
-
   // Version info
   const [versionInfo, setVersionInfo] = useState(null);
 
@@ -125,8 +108,6 @@ function Settings({ user, isMobile = false, setUseDesktopInterface }) {
     loadSettings();
     loadUserSettings();
     loadVersionInfo();
-    loadMyEmail();
-    loadEmailStatus();
     if (supportsPasskeys()) {
       loadPasskeys();
     }
@@ -447,92 +428,6 @@ function Settings({ user, isMobile = false, setUseDesktopInterface }) {
     setRecoveryCodes(null);
   };
 
-  const loadEmailStatus = async () => {
-    try {
-      const res = await notificationsAPI.getStatus();
-      setEmailConfigured(res.data.configured);
-    } catch {
-      setEmailConfigured(false);
-    }
-  };
-
-  const loadMyEmail = async () => {
-    try {
-      const res = await notificationsAPI.getMyEmail();
-      setMyEmail(res.data.email || '');
-      setEmailInput(res.data.email || '');
-      setMyEmailVerified(res.data.email_verified || false);
-    } catch {
-      // ignore – non-critical
-    }
-  };
-
-  const handleSaveEmail = async () => {
-    setEmailError('');
-    setEmailSuccess('');
-    setEmailLoading(true);
-    try {
-      const res = await notificationsAPI.updateMyEmail(emailInput.trim());
-      setMyEmail(res.data.email || '');
-      setMyEmailVerified(res.data.email_verified || false);
-      setVerificationCode('');
-      setVerifyError('');
-      setVerifySuccess('');
-      if (res.data.verification_required) {
-        setEmailSuccess(`Verification code sent to ${res.data.email}`);
-      } else if (!res.data.email) {
-        setEmailSuccess('Email address removed.');
-      } else {
-        setEmailSuccess(res.data.message || 'Email updated.');
-      }
-    } catch (err) {
-      setEmailError(err.response?.data?.error || 'Failed to save email address.');
-    } finally {
-      setEmailLoading(false);
-    }
-  };
-
-  const handleVerifyCode = async () => {
-    setVerifyError('');
-    setVerifySuccess('');
-    setVerifyLoading(true);
-    try {
-      await notificationsAPI.verifyEmail(verificationCode.trim());
-      setMyEmailVerified(true);
-      setVerifySuccess('Email verified!');
-      setVerificationCode('');
-    } catch (err) {
-      setVerifyError(err.response?.data?.error || 'Verification failed.');
-    } finally {
-      setVerifyLoading(false);
-    }
-  };
-
-  const handleResendCode = async () => {
-    setVerifyError('');
-    setVerifySuccess('');
-    try {
-      await notificationsAPI.resendVerification();
-      setVerifySuccess(`New code sent to ${myEmail}`);
-    } catch (err) {
-      setVerifyError(err.response?.data?.error || 'Failed to resend code.');
-    }
-  };
-
-  const handleSendTestEmail = async () => {
-    setTestEmailError('');
-    setTestEmailSuccess('');
-    setTestEmailLoading(true);
-    try {
-      const res = await notificationsAPI.sendTestEmail();
-      setTestEmailSuccess(res.data.message || 'Test email sent.');
-    } catch (err) {
-      setTestEmailError(err.response?.data?.error || 'Failed to send test email.');
-    } finally {
-      setTestEmailLoading(false);
-    }
-  };
-
   if (loading) {
     return (
       <div className="container">
@@ -758,144 +653,12 @@ function Settings({ user, isMobile = false, setUseDesktopInterface }) {
 
       {/* ── Email Notifications ──────────────────────────────────── */}
       <SettingsSection title="Email Notifications">
-        {!emailConfigured && (
-          <div style={{
-            padding: '0.75rem 1rem',
-            background: '#fff3cd',
-            border: '1px solid #ffc107',
-            borderRadius: '4px',
-            marginBottom: '1rem',
-            fontSize: '0.9rem',
-            color: '#856404',
-          }}>
-            Email notifications are not configured on this server.
-          </div>
-        )}
-
-        {emailError && <div className="error-message">{emailError}</div>}
-        {emailSuccess && <div className="success-message">{emailSuccess}</div>}
-
-        <div className="form-group">
-          <label htmlFor="notification_email">Notification email address</label>
-          <small style={{ color: '#7f8c8d', display: 'block', marginBottom: '0.5rem' }}>
-            Receive alerts (e.g. items expiring soon) at this address.
-            Your email must be verified before notifications are sent.
-          </small>
-
-          {myEmail && (
-            <div style={{ marginBottom: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-              <span style={{ fontSize: '0.9rem', color: '#495057' }}>{myEmail}</span>
-              {myEmailVerified ? (
-                <span style={{
-                  fontSize: '0.75rem', background: '#d4edda', color: '#155724',
-                  padding: '0.15rem 0.5rem', borderRadius: '3px', fontWeight: '600',
-                }}>Verified</span>
-              ) : (
-                <span style={{
-                  fontSize: '0.75rem', background: '#fff3cd', color: '#856404',
-                  padding: '0.15rem 0.5rem', borderRadius: '3px', fontWeight: '600',
-                }}>Not verified</span>
-              )}
-            </div>
-          )}
-
-          <div style={{ display: 'flex', gap: '0.5rem' }}>
-            <input
-              type="email"
-              id="notification_email"
-              value={emailInput}
-              onChange={(e) => setEmailInput(e.target.value)}
-              placeholder="you@example.com"
-              style={{ flex: 1 }}
-              disabled={!emailConfigured}
-            />
-            <button
-              className="btn btn-primary"
-              onClick={handleSaveEmail}
-              disabled={emailLoading || !emailConfigured}
-            >
-              {emailLoading ? 'Saving…' : 'Save'}
-            </button>
-            {myEmail && (
-              <button
-                className="btn btn-secondary"
-                onClick={() => { setEmailInput(''); }}
-                style={{ whiteSpace: 'nowrap' }}
-                disabled={emailLoading || !emailConfigured}
-              >
-                Clear
-              </button>
-            )}
-          </div>
-        </div>
-
-        {/* Verification code entry */}
-        {myEmail && !myEmailVerified && (
-          <div style={{
-            marginTop: '1.25rem',
-            padding: '1rem',
-            background: '#f8f9fa',
-            border: '1px solid #e9ecef',
-            borderRadius: '6px',
-          }}>
-            <h4 style={{ margin: '0 0 0.75rem', fontSize: '0.95rem' }}>Verify your email</h4>
-            <p style={{ margin: '0 0 0.75rem', fontSize: '0.875rem', color: '#7f8c8d' }}>
-              Enter the 6-digit code sent to <strong>{myEmail}</strong>.
-            </p>
-
-            {verifyError && <div className="error-message" style={{ marginBottom: '0.75rem' }}>{verifyError}</div>}
-            {verifySuccess && <div className="success-message" style={{ marginBottom: '0.75rem' }}>{verifySuccess}</div>}
-
-            <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
-              <input
-                type="text"
-                value={verificationCode}
-                onChange={(e) => setVerificationCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
-                placeholder="123456"
-                maxLength={6}
-                style={{ width: '8rem', fontFamily: 'monospace', fontSize: '1.25rem', letterSpacing: '0.2em', textAlign: 'center' }}
-              />
-              <button
-                className="btn btn-primary"
-                onClick={handleVerifyCode}
-                disabled={verifyLoading || verificationCode.length !== 6}
-              >
-                {verifyLoading ? 'Verifying…' : 'Verify'}
-              </button>
-              <button
-                className="btn btn-secondary"
-                onClick={handleResendCode}
-                style={{ fontSize: '0.85rem' }}
-              >
-                Resend code
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* Test email */}
-        {emailConfigured && (
-          <div style={{ marginTop: '1.25rem', paddingTop: '1.25rem', borderTop: '1px solid #e9ecef' }}>
-            <h4 style={{ margin: '0 0 0.5rem', fontSize: '0.95rem' }}>Send test email</h4>
-            <p style={{ margin: '0 0 0.75rem', fontSize: '0.875rem', color: '#7f8c8d' }}>
-              Verify Resend is configured correctly. The test email will be sent to your verified address.
-            </p>
-            {testEmailError && <div className="error-message" style={{ marginBottom: '0.75rem' }}>{testEmailError}</div>}
-            {testEmailSuccess && <div className="success-message" style={{ marginBottom: '0.75rem' }}>{testEmailSuccess}</div>}
-            <button
-              className="btn btn-secondary"
-              onClick={handleSendTestEmail}
-              disabled={testEmailLoading || !myEmailVerified}
-            >
-              {testEmailLoading ? 'Sending…' : 'Send Test Email'}
-            </button>
-            {!myEmailVerified && (
-              <small style={{ color: '#856404', marginLeft: '0.75rem' }}>
-                Verify your email address above to enable this.
-              </small>
-            )}
-          </div>
-        )}
+        <p style={{ margin: '0 0 0.75rem', fontSize: '0.9rem', color: '#495057' }}>
+          Manage your notification email address, low-stock alerts, and more.
+        </p>
+        <Link to="/notifications" className="btn btn-primary" style={{ display: 'inline-block' }}>
+          Go to Notifications settings
+        </Link>
       </SettingsSection>
 
       {/* ── Admin sections ───────────────────────────────────────── */}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -407,6 +407,19 @@ export const notificationsAPI = {
 
   sendTestEmail: () =>
     api.post('/notifications/email/test'),
+
+  // Low-stock alerts
+  getLowStockAlerts: () =>
+    api.get('/notifications/low-stock'),
+
+  createLowStockAlert: (item_name, threshold) =>
+    api.post('/notifications/low-stock', { item_name, threshold }),
+
+  updateLowStockAlert: (id, data) =>
+    api.put(`/notifications/low-stock/${id}`, data),
+
+  deleteLowStockAlert: (id) =>
+    api.delete(`/notifications/low-stock/${id}`),
 };
 
 export default api;


### PR DESCRIPTION
- New LowStockAlert model: per-user alerts with item name, threshold, enabled toggle, and last-sent timestamp (24h cooldown)
- Backend CRUD routes: GET/POST/PUT/DELETE /api/notifications/low-stock
- After an item is consumed or thrown out, check_and_send_low_stock_alerts fires an email to any user whose alert threshold >= remaining count
- New EmailNotifications page (/notifications): email address setup, 6-digit verification, test email, and low-stock alert management with item-name autocomplete and inline threshold editing
- Notifications link added to desktop and mobile navbars
- Settings page Email Notifications section replaced with a link to the new dedicated page

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH