### PR TITLE
fix: use sudo to clear frontend/dist on deployment

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -113,7 +113,7 @@ jobs:
 
             # Clear stale dist so the SCP upload replaces it cleanly
             echo "Clearing old frontend dist..."
-            rm -rf frontend/dist
+            sudo rm -rf frontend/dist
             mkdir -p frontend/dist
             echo "✓ Ready for dist upload"
 

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -110,7 +110,7 @@ jobs:
 
             # Clear stale dist so the SCP upload replaces it cleanly
             echo "Clearing old frontend dist..."
-            rm -rf frontend/dist
+            sudo rm -rf frontend/dist
             mkdir -p frontend/dist
             echo "✓ Ready for dist upload"
 


### PR DESCRIPTION
The dist files from a previous deployment were owned by a different user, causing `rm -rf frontend/dist` to fail with Permission denied. Use sudo to ensure the directory is always removable regardless of ownership.

Applied to both dev and prod deployment workflows.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH