### PR TITLE
fix: make frontend dist cleanup non-fatal to unblock deployments

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -111,9 +111,16 @@ jobs:
             cd ..
             echo "✓ Database migrations complete"
 
-            # Clear stale dist so the SCP upload replaces it cleanly
+            # Clear stale dist so the SCP upload replaces it cleanly.
+            # Fix ownership of any root-owned files from prior deployments, then
+            # remove the directory. Both are best-effort; if they fail (e.g. no
+            # passwordless sudo configured yet), SCP will still overwrite same-named
+            # files and new hashed filenames will be added alongside old ones.
+            # Run `sudo chown -R michaelt452:michaelt452 frontend/dist` on the server
+            # once to permanently resolve ownership and enable clean removal each deploy.
             echo "Clearing old frontend dist..."
-            sudo rm -rf frontend/dist
+            sudo chown -R "$(whoami)":"$(whoami)" frontend/dist 2>/dev/null || true
+            rm -rf frontend/dist 2>/dev/null || true
             mkdir -p frontend/dist
             echo "✓ Ready for dist upload"
 

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -108,9 +108,16 @@ jobs:
             cd ..
             echo "✓ Database migrations complete"
 
-            # Clear stale dist so the SCP upload replaces it cleanly
+            # Clear stale dist so the SCP upload replaces it cleanly.
+            # Fix ownership of any root-owned files from prior deployments, then
+            # remove the directory. Both are best-effort; if they fail (e.g. no
+            # passwordless sudo configured yet), SCP will still overwrite same-named
+            # files and new hashed filenames will be added alongside old ones.
+            # Run `sudo chown -R michaelt452:michaelt452 frontend/dist` on the server
+            # once to permanently resolve ownership and enable clean removal each deploy.
             echo "Clearing old frontend dist..."
-            sudo rm -rf frontend/dist
+            sudo chown -R "$(whoami)":"$(whoami)" frontend/dist 2>/dev/null || true
+            rm -rf frontend/dist 2>/dev/null || true
             mkdir -p frontend/dist
             echo "✓ Ready for dist upload"
 


### PR DESCRIPTION
sudo chown + rm -rf are best-effort (|| true) so a deployment is never blocked by root-owned files from a prior manual setup. SCP still delivers the new build; old hashed files accumulate harmlessly until ownership is fixed on the server with:
  sudo chown -R michaelt452:michaelt452 frontend/dist

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH