### PR TITLE
fix: add overwrite: true to scp-action to handle existing files

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -140,6 +140,7 @@ jobs:
           source: "frontend/dist"
           target: "/home/michaelt452/freezer-inventory-dev/frontend"
           strip_components: 1
+          overwrite: true
 
       - name: Restart services & health check
         uses: appleboy/ssh-action@v1.2.5

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -137,6 +137,7 @@ jobs:
           source: "frontend/dist"
           target: "/home/michaelt452/freezer-inventory/frontend"
           strip_components: 1
+          overwrite: true
 
       - name: Restart services & health check
         uses: appleboy/ssh-action@v1.2.5


### PR DESCRIPTION
Without this, tar refuses to extract over same-named files and the upload fails. overwrite: true forces replacement of existing files.

Note: root-owned files from prior manual setup still require a one-time
server-side fix: sudo chown -R michaelt452:michaelt452 frontend/dist

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH