### PR TITLE
fix: run npm install on server and add frontend journal logs on failure

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -101,6 +101,13 @@ jobs:
             cd ..
             echo "✓ Backend dependencies updated"
 
+            # Update frontend dependencies
+            echo "Updating frontend dependencies..."
+            cd frontend
+            npm install --silent
+            cd ..
+            echo "✓ Frontend dependencies updated"
+
             # Run database migrations
             echo "Running database migrations..."
             cd backend
@@ -185,6 +192,8 @@ jobs:
               if [ $i -eq 6 ]; then
                 echo "✗ Frontend health check failed after 30s!"
                 sudo systemctl status freezer-frontend-dev --no-pager
+                echo "--- Recent logs ---"
+                sudo journalctl -u freezer-frontend-dev -n 50 --no-pager
                 exit 1
               fi
               echo "  Waiting for frontend... (attempt $i/6)"

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -98,6 +98,13 @@ jobs:
             cd ..
             echo "✓ Backend dependencies updated"
 
+            # Update frontend dependencies
+            echo "Updating frontend dependencies..."
+            cd frontend
+            npm install --silent
+            cd ..
+            echo "✓ Frontend dependencies updated"
+
             # Run database migrations
             echo "Running database migrations..."
             cd backend
@@ -182,6 +189,8 @@ jobs:
               if [ $i -eq 6 ]; then
                 echo "✗ Frontend health check failed after 30s!"
                 sudo systemctl status freezer-frontend --no-pager
+                echo "--- Recent logs ---"
+                sudo journalctl -u freezer-frontend -n 50 --no-pager
                 exit 1
               fi
               echo "  Waiting for frontend... (attempt $i/6)"


### PR DESCRIPTION
- Add npm install step so server frontend dependencies stay in sync
- Print journalctl logs on frontend health check failure (matches backend)

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH