### PR TITLE
fix: prevent frontend service crash when public/ is not writable

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -127,6 +127,7 @@ jobs:
             # once to permanently resolve ownership and enable clean removal each deploy.
             echo "Clearing old frontend dist..."
             sudo chown -R "$(whoami)":"$(whoami)" frontend/dist 2>/dev/null || true
+            sudo chown -R "$(whoami)":"$(whoami)" frontend/public 2>/dev/null || true
             rm -rf frontend/dist 2>/dev/null || true
             mkdir -p frontend/dist
             echo "✓ Ready for dist upload"

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -124,6 +124,7 @@ jobs:
             # once to permanently resolve ownership and enable clean removal each deploy.
             echo "Clearing old frontend dist..."
             sudo chown -R "$(whoami)":"$(whoami)" frontend/dist 2>/dev/null || true
+            sudo chown -R "$(whoami)":"$(whoami)" frontend/public 2>/dev/null || true
             rm -rf frontend/dist 2>/dev/null || true
             mkdir -p frontend/dist
             echo "✓ Ready for dist upload"

--- a/frontend/scripts/generate-version.js
+++ b/frontend/scripts/generate-version.js
@@ -93,6 +93,5 @@ try {
   console.log(`  Environment: ${isDev ? 'Development' : 'Production'}`);
   console.log(`  App Name: ${manifest.short_name}`);
 } catch (error) {
-  console.error('Error writing files:', error);
-  process.exit(1);
+  console.warn('Warning: Could not write version/manifest files:', error.message);
 }


### PR DESCRIPTION
generate-version.js called process.exit(1) if it couldn't write version.json/manifest.json, causing the npm run dev command to exit before Vite started. Changed to a warning so the service starts even if the public/ dir has a permissions issue. Also fix frontend/public ownership on every deploy (alongside existing frontend/dist fix).

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH