### PR TITLE
fix: make frontend/public world-writable and add failure diagnostics

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -131,6 +131,8 @@ jobs:
             echo "Clearing old frontend dist..."
             sudo chown -R "$(whoami)":"$(whoami)" frontend/dist 2>/dev/null || true
             sudo chown -R "$(whoami)":"$(whoami)" frontend/public 2>/dev/null || true
+            # Make public writable by any service user so generate-version.js can write version.json
+            chmod -R a+w frontend/public 2>/dev/null || true
             rm -rf frontend/dist 2>/dev/null || true
             mkdir -p frontend/dist
             echo "✓ Ready for dist upload"
@@ -196,8 +198,12 @@ jobs:
               if [ $i -eq 6 ]; then
                 echo "✗ Frontend health check failed after 30s!"
                 sudo systemctl status freezer-frontend-dev --no-pager
+                echo "--- Service file ---"
+                cat /etc/systemd/system/freezer-frontend-dev.service 2>/dev/null || true
                 echo "--- Recent logs ---"
                 journalctl -u freezer-frontend-dev -n 50 --no-pager 2>/dev/null || sudo journalctl -u freezer-frontend-dev -n 50 --no-pager 2>/dev/null || true
+                echo "--- Manual run (5s timeout) ---"
+                cd /home/michaelt452/freezer-inventory-dev/frontend && timeout 5 node scripts/generate-version.js 2>&1 || true
                 exit 1
               fi
               echo "  Waiting for frontend... (attempt $i/6)"


### PR DESCRIPTION
generate-version.js exits with code 1 if it cannot write version.json. The service may run as a different user than gh-deploy, so chown alone is not enough. Adding chmod a+w ensures any service user can write.

Also adds service file content and a manual generate-version.js run to the frontend failure handler so we can see the exact error.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH