### PR TITLE
fix: chown node_modules to michaelt452 after npm install

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -107,6 +107,8 @@ jobs:
             echo "Updating frontend dependencies..."
             cd frontend
             npm install --silent
+            # Fix ownership: service runs as michaelt452 but npm install runs as gh-deploy
+            sudo chown -R michaelt452:michaelt452 node_modules 2>/dev/null || true
             cd ..
             echo "✓ Frontend dependencies updated"
 


### PR DESCRIPTION
The service runs as User=michaelt452, but npm install runs as gh-deploy. This causes vite to fail with EACCES when it tries to write its temp config file into node_modules/.vite-temp/ on startup.

The vite dry-run (as gh-deploy) confirmed vite itself works fine.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH