### PR TITLE
fix: rm .vite-temp and chmod o+w node_modules so service can start vite

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -107,8 +107,10 @@ jobs:
             echo "Updating frontend dependencies..."
             cd frontend
             npm install --silent
-            # Fix ownership: service runs as michaelt452 but npm install runs as gh-deploy
-            sudo chown -R michaelt452:michaelt452 node_modules 2>/dev/null || true
+            # Delete vite's temp dir so the service (michaelt452) can recreate it as its own user.
+            # node_modules is owned by gh-deploy, so michaelt452 can't create subdirs without o+w.
+            rm -rf node_modules/.vite-temp 2>/dev/null || true
+            chmod o+w node_modules
             cd ..
             echo "✓ Frontend dependencies updated"
 


### PR DESCRIPTION
sudo chown was failing silently (gh-deploy sudoers restricts target user). The real fix: delete any stale .vite-temp owned by gh-deploy, then grant world-write on node_modules so michaelt452 (service user) can create .vite-temp fresh at startup. No sudo required since gh-deploy owns node_modules.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH