### PR TITLE
fix: re-pin webauthn==2.2.0 (reverts accidental unpinning)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,4 +15,4 @@ psycopg2-binary==2.9.11  # PostgreSQL adapter (optional, for PostgreSQL support)
 pytest==9.0.2
 pytest-flask==1.3.0
 pytest-cov==7.0.0
-webauthn>=2.2.0
+webauthn==2.2.0


### PR DESCRIPTION
A previous commit loosened webauthn==2.2.0 to webauthn>=2.2.0 "for compatibility". This caused pip install to upgrade to a newer version with a changed API, breaking all passkey routes with 500 errors.

Pinning back to the exact version that was tested and working.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH