### PR TITLE
fix: chown DB files after migrations to prevent readonly error

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -128,6 +128,11 @@ jobs:
             python3 migrations/run_email_verification_migration.py || echo "⚠️  Email verification migration already applied or not needed"
             python3 migrations/run_low_stock_alerts_migration.py || echo "⚠️  Low-stock migration already applied or not needed"
             python3 migrations/run_passkey_migration.py || echo "⚠️  Passkey migration already applied or not needed"
+            # Fix ownership: migrations run as gh-deploy but gunicorn runs as michaelt452.
+            # Any SQLite journal/WAL files created during migration must be owned by the
+            # service user, otherwise gunicorn gets "attempt to write a readonly database".
+            sudo chown michaelt452:michaelt452 instance/*.db 2>/dev/null || true
+            sudo rm -f instance/*.db-journal instance/*.db-wal instance/*.db-shm 2>/dev/null || true
             cd ..
             echo "✓ Database migrations complete"
 

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -116,6 +116,11 @@ jobs:
             python3 migrations/run_email_verification_migration.py || echo "⚠️  Email verification migration already applied or not needed"
             python3 migrations/run_low_stock_alerts_migration.py || echo "⚠️  Low-stock migration already applied or not needed"
             python3 migrations/run_passkey_migration.py || echo "⚠️  Passkey migration already applied or not needed"
+            # Fix ownership: migrations run as gh-deploy but gunicorn runs as michaelt452.
+            # Any SQLite journal/WAL files created during migration must be owned by the
+            # service user, otherwise gunicorn gets "attempt to write a readonly database".
+            sudo chown michaelt452:michaelt452 instance/*.db 2>/dev/null || true
+            sudo rm -f instance/*.db-journal instance/*.db-wal instance/*.db-shm 2>/dev/null || true
             cd ..
             echo "✓ Database migrations complete"
 


### PR DESCRIPTION
Migrations run as gh-deploy; gunicorn runs as michaelt452. SQLite creates journal/WAL files during writes, so after migrations the DB files may be gh-deploy-owned and unwritable by the service user.

Add chown + auxiliary file cleanup after the migration block in both deploy workflows to prevent "attempt to write a readonly database".

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH