### PR TITLE
fix: chmod instance/ dir writable so SQLite can create lock files

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -133,6 +133,9 @@ jobs:
             # service user, otherwise gunicorn gets "attempt to write a readonly database".
             sudo chown michaelt452:michaelt452 instance/*.db 2>/dev/null || true
             sudo rm -f instance/*.db-journal instance/*.db-wal instance/*.db-shm 2>/dev/null || true
+            # Ensure the instance directory is writable by michaelt452 (the service user).
+            # SQLite must create journal/lock files in the same directory as the DB.
+            sudo chmod o+w instance/ 2>/dev/null || true
             cd ..
             echo "✓ Database migrations complete"
 

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -121,6 +121,9 @@ jobs:
             # service user, otherwise gunicorn gets "attempt to write a readonly database".
             sudo chown michaelt452:michaelt452 instance/*.db 2>/dev/null || true
             sudo rm -f instance/*.db-journal instance/*.db-wal instance/*.db-shm 2>/dev/null || true
+            # Ensure the instance directory is writable by michaelt452 (the service user).
+            # SQLite must create journal/lock files in the same directory as the DB.
+            sudo chmod o+w instance/ 2>/dev/null || true
             cd ..
             echo "✓ Database migrations complete"
 


### PR DESCRIPTION
The instance/ directory is owned by gh-deploy, leaving michaelt452 (the gunicorn user) with only r-x. SQLite requires write access to the directory to create journal/WAL/SHM lock files alongside the DB. Without it every write attempt fails with "attempt to write a readonly database" or "database is locked".

Add `chmod o+w instance/` after migrations in both deploy workflows.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH