### PR TITLE
fix: guard getItemNames call so missing function fails silently

### DIFF
--- a/frontend/src/components/AddItemModal.jsx
+++ b/frontend/src/components/AddItemModal.jsx
@@ -42,6 +42,7 @@ function AddItemModal({ item, categories, onClose, onSave, onCategoryCreated, qr
 
   // Fetch distinct names + sources for autocomplete on mount
   useEffect(() => {
+    if (typeof itemsAPI.getItemNames !== 'function') return;
     itemsAPI.getItemNames('all').then((res) => {
       setNameSuggestions(res.data.names || []);
       setSourceSuggestions(res.data.sources || []);


### PR DESCRIPTION
.catch() only catches async rejections; a synchronous TypeError from calling undefined-as-a-function escapes it and crashes the component. Add an explicit typeof guard so AddItemModal degrades gracefully if the /items/names endpoint isn't available in the running build.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH