### PR TITLE
fix: chown backend dir after git reset so gunicorn can create control…

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -83,6 +83,11 @@ jobs:
             echo "Pulling latest code from dev..."
             git fetch origin
             git reset --hard origin/dev
+            # gunicorn 22+ creates gunicorn.ctl in the working directory.
+            # After git reset (which runs as gh-deploy), backend/ is owned by
+            # gh-deploy. Fix ownership so the service user (michaelt452) can
+            # create that socket when gunicorn starts.
+            sudo chown michaelt452:michaelt452 backend
             echo "✓ Code updated"
 
             # Stop services before updating dependencies


### PR DESCRIPTION
… socket

Gunicorn 25.x creates a gunicorn.ctl control socket in the working directory on startup. After git reset --hard (which runs as gh-deploy), the backend/ directory is owned by gh-deploy. The service user (michaelt452) gets EACCES when trying to create the socket, causing the backend to fail its health check on every deployment.

Fix: chown backend/ to michaelt452 immediately after git reset.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH