### PR TITLE
fix: remove redundant Done button from success screen

### DIFF
--- a/frontend/src/components/AddItemModal.jsx
+++ b/frontend/src/components/AddItemModal.jsx
@@ -537,12 +537,6 @@ function AddItemModal({ item, categories, onClose, onSave, onCategoryCreated, qr
               }}>
                 {lastAddedCode}
               </div>
-              <button
-                className="btn btn-primary"
-                onClick={() => onSave()}
-              >
-                Done
-              </button>
             </div>
           )}
           {!showSuccess && error && <div className="error-message">{error}</div>}


### PR DESCRIPTION
The modal's existing Close button already serves as the dismiss action.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH