### PR TITLE
fix: skip devDependencies on server to prevent npm install OOM

### DIFF
--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -113,7 +113,7 @@ jobs:
             # Update frontend dependencies
             echo "Updating frontend dependencies..."
             cd frontend
-            npm install --silent
+            npm install --omit=dev --silent
             # Delete vite's temp dir so the service (michaelt452) can recreate it as its own user.
             # node_modules is owned by gh-deploy, so michaelt452 can't create subdirs without o+w.
             rm -rf node_modules/.vite-temp 2>/dev/null || true

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.1",
-    "recharts": "^3.7.0"
+    "recharts": "^3.7.0",
+    "vite": "^7.3.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.5",
@@ -32,7 +33,6 @@
     "@vitest/ui": "^4.0.16",
     "esbuild": "^0.27.3",
     "jsdom": "^28.1.0",
-    "vite": "^7.3.1",
     "vitest": "^4.0.16"
   }
 }


### PR DESCRIPTION
The small GCP VM was crashing (exit 243) during npm install because it was downloading all devDependencies: vitest, jsdom, esbuild binary, testing-library, coverage tools, etc.

The server only needs vite to run `vite preview`. Moving vite to dependencies and passing --omit=dev to npm install cuts the install footprint dramatically — only runtime packages are installed.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH