### PR TITLE
fix: remove service user override block that breaks deploy

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -99,17 +99,6 @@ jobs:
             sudo rm -f backend/instance/*.db-wal backend/instance/*.db-shm 2>/dev/null || true
             echo "✓ Services stopped"
 
-            # Ensure both services run as gh-deploy (same user as this deploy script).
-            # Use a drop-in override (same tee pattern setup uses) rather than sed -i,
-            # since gh-deploy's sudoers may not allow arbitrary sed on system files.
-            echo "Ensuring service user is gh-deploy..."
-            for svc in freezer-backend-dev freezer-frontend-dev; do
-              sudo mkdir -p /etc/systemd/system/$svc.service.d
-              printf '[Service]\nUser=gh-deploy\n' | sudo tee /etc/systemd/system/$svc.service.d/user.conf > /dev/null 2>&1 || true
-            done
-            sudo systemctl daemon-reload
-            echo "✓ Service user verified"
-
             # Update backend dependencies
             echo "Updating backend dependencies..."
             cd backend


### PR DESCRIPTION
sudo mkdir on /etc/systemd/system/ is not in gh-deploy sudoers, causing set -e to abort the entire deploy step. The service user fix attempts (sed, tee, mkdir) all require filesystem access to /etc/systemd that gh-deploy doesn't have passwordlessly.

The chmod o+w / sudo rm -rf workarounds for the michaelt452 service user are sufficient and remain in place.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH