### PR TITLE
fix: recreate vite cache dirs with 777 so michaelt452 can write inside

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -114,9 +114,15 @@ jobs:
             # Purge vite's cache dirs. They may be owned by a different user from a
             # previous run; the service user must be able to delete/recreate them.
             sudo rm -rf node_modules/.vite node_modules/.vite-temp 2>/dev/null || true
-            # Open node_modules and public so the service user can write into them
-            # (create new .vite dirs, write manifest.json via generate-version.js).
-            chmod o+w node_modules
+            # Re-create vite cache dirs as gh-deploy with open permissions so the
+            # service user (michaelt452) can create/delete subdirs inside them.
+            # chmod o+w on the parent is not enough — subdirs need 777 themselves.
+            mkdir -p node_modules/.vite node_modules/.vite-temp
+            chmod 777 node_modules/.vite node_modules/.vite-temp
+            # Remove manifest.json if owned by gh-deploy; michaelt452 must write it
+            # fresh via generate-version.js on startup. chmod o+w public lets it create
+            # new files there but won't let it overwrite an existing gh-deploy-owned file.
+            rm -f public/manifest.json 2>/dev/null || true
             chmod o+w public
             cd ..
             echo "✓ Frontend dependencies updated"


### PR DESCRIPTION
chmod o+w on node_modules is not sufficient — when gh-deploy creates .vite and .vite-temp via npm install, those dirs are owned by gh-deploy with mode 755, so michaelt452 (the service user) can't rmdir/create subdirectories inside them (e.g. .vite/deps), causing vite to crash.

Fix: delete the dirs then recreate them as gh-deploy with chmod 777, so michaelt452 can freely create/delete subdirs inside at runtime.

Also delete public/manifest.json before restart; chmod o+w on the public directory lets michaelt452 create new files but not overwrite an existing file owned by gh-deploy.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH