### PR TITLE
fix: drop sudo from vite cache rm, make chmod non-fatal

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -113,12 +113,16 @@ jobs:
             npm install --silent
             # Purge vite's cache dirs. They may be owned by a different user from a
             # previous run; the service user must be able to delete/recreate them.
-            sudo rm -rf node_modules/.vite node_modules/.vite-temp 2>/dev/null || true
-            # Re-create vite cache dirs as gh-deploy with open permissions so the
-            # service user (michaelt452) can create/delete subdirs inside them.
-            # chmod o+w on the parent is not enough — subdirs need 777 themselves.
+            # Remove vite cache dirs if gh-deploy owns them (plain rm works for our
+            # files; sudo rm is not allowed for arbitrary paths). If michaelt452 owns
+            # them from a previous service run they survive — that's fine, it can write
+            # to its own dirs already.
+            rm -rf node_modules/.vite node_modules/.vite-temp 2>/dev/null || true
+            # Re-create with 777 so the service user can write inside when gh-deploy
+            # created them fresh. If dirs still exist (owned by michaelt452), chmod
+            # fails silently via || true — michaelt452 has full access as owner anyway.
             mkdir -p node_modules/.vite node_modules/.vite-temp
-            chmod 777 node_modules/.vite node_modules/.vite-temp
+            chmod 777 node_modules/.vite node_modules/.vite-temp 2>/dev/null || true
             # Remove manifest.json if owned by gh-deploy; michaelt452 must write it
             # fresh via generate-version.js on startup. chmod o+w public lets it create
             # new files there but won't let it overwrite an existing gh-deploy-owned file.


### PR DESCRIPTION
sudo rm -rf is not in gh-deploy's sudoers for arbitrary paths, so .vite-temp owned by michaelt452 survived the delete, mkdir -p was a no-op, and chmod 777 then failed with EPERM (can't chmod another user's files).

Plain rm -rf (no sudo) works when gh-deploy owns the dirs (the normal case after npm install). If michaelt452 owns the dirs from a previous service run, rm fails silently and chmod fails silently via || true — but that's fine because michaelt452 already has full access as owner.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH