### PR TITLE
fix(prod): chown node_modules back to deploy user before npm install

### DIFF
--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -113,6 +113,10 @@ jobs:
             # Update frontend dependencies
             echo "Updating frontend dependencies..."
             cd frontend
+            # Reclaim ownership of any node_modules files written by the service user
+            # (michaelt452). npm rename-renames within node_modules fail with EACCES
+            # when it doesn't own a subdir. sudo chown is available via sudoers.
+            sudo chown -R "$(whoami)":"$(whoami)" node_modules 2>/dev/null || true
             npm install --omit=dev
             # Remove vite cache dirs if gh-deploy owns them (plain rm works for our
             # files; sudo rm is not allowed for arbitrary paths). If michaelt452 owns


### PR DESCRIPTION
node_modules subdirs written by the service user (michaelt452) caused EACCES when npm tried to rename them during install (e.g. @acemir/cssom). Reclaim ownership with sudo chown before running npm install --omit=dev.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH