### PR TITLE
fix(prod): revert sudo rm, restore plain npm install --omit=dev

### DIFF
--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -113,11 +113,6 @@ jobs:
             # Update frontend dependencies
             echo "Updating frontend dependencies..."
             cd frontend
-            # Wipe node_modules entirely so npm install always starts from a clean
-            # slate owned by the deploy user (gh-deploy). Mixed ownership from the
-            # service user (michaelt452) causes EACCES on atomic renames inside npm.
-            # sudo rm is needed because michaelt452-owned subdirs resist plain rm.
-            sudo rm -rf node_modules
             npm install --omit=dev
             # Create vite cache dirs with open permissions so the service user
             # (michaelt452) can write its own cache inside them on startup.


### PR DESCRIPTION
sudo rm -rf node_modules doesn't have permission in the sudoers config. The correct fix is a one-time manual chown on the server to restore gh-deploy ownership of node_modules, after which plain npm install works.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH