### PR TITLE
fix: move @vitejs/plugin-react to dependencies for prod deploy

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.1",
     "recharts": "^3.7.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "@vitejs/plugin-react": "^5.1.4"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.5",
@@ -28,7 +29,6 @@
     "@testing-library/user-event": "^14.5.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^5.1.4",
     "@vitest/coverage-v8": "^4.0.18",
     "@vitest/ui": "^4.0.16",
     "esbuild": "^0.27.3",


### PR DESCRIPTION
vite preview loads vite.config.js which imports @vitejs/plugin-react. Since deploy runs npm install --omit=dev, this package was missing at runtime. Moving it from devDependencies to dependencies fixes the frontend startup failure.

https://claude.ai/code/session_016qRuTf4mo2QMGPsupmQQyH