### PR TITLE
Add expiration alert email notifications with category filtering

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yml
+++ b/.github/workflows/deploy-dev-gcp.yml
@@ -41,11 +41,12 @@ jobs:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           EMAIL_FROM_ADDRESS: ${{ vars.EMAIL_FROM_ADDRESS }}
           EMAIL_FROM_NAME: ${{ vars.EMAIL_FROM_NAME }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
         with:
           host: ${{ secrets.GCP_DEV_HOST }}
           username: ${{ secrets.GCP_USERNAME }}
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
-          envs: UPC_API_KEY,PEXELS_API_KEY,RESEND_API_KEY,EMAIL_FROM_ADDRESS,EMAIL_FROM_NAME
+          envs: UPC_API_KEY,PEXELS_API_KEY,RESEND_API_KEY,EMAIL_FROM_ADDRESS,EMAIL_FROM_NAME,CRON_SECRET
           # timeout: SSH dial+handshake timeout. Fail fast if the server is
           # unresponsive instead of hanging for 29+ minutes (which previously
           # triggered fail2ban bans from repeated retry attempts).
@@ -68,6 +69,7 @@ jobs:
             RESEND_API_KEY=${RESEND_API_KEY}
             EMAIL_FROM_ADDRESS=${EMAIL_FROM_ADDRESS}
             EMAIL_FROM_NAME=${EMAIL_FROM_NAME:-Freezer Inventory}
+            CRON_SECRET=${CRON_SECRET}
             EOF
             echo "✓ Environment variables configured"
 
@@ -140,6 +142,7 @@ jobs:
             python3 migrations/run_email_verification_migration.py || echo "⚠️  Email verification migration already applied or not needed"
             python3 migrations/run_low_stock_alerts_migration.py || echo "⚠️  Low-stock migration already applied or not needed"
             python3 migrations/run_passkey_migration.py || echo "⚠️  Passkey migration already applied or not needed"
+            python3 migrations/run_expiration_notifications_migration.py || echo "⚠️  Expiration notifications migration already applied or not needed"
             sudo rm -f instance/*.db-journal instance/*.db-wal instance/*.db-shm 2>/dev/null || true
             cd ..
             echo "✓ Database migrations complete"

--- a/.github/workflows/deploy-prod-gcp.yml
+++ b/.github/workflows/deploy-prod-gcp.yml
@@ -41,11 +41,12 @@ jobs:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           EMAIL_FROM_ADDRESS: ${{ vars.EMAIL_FROM_ADDRESS }}
           EMAIL_FROM_NAME: ${{ vars.EMAIL_FROM_NAME }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
         with:
           host: ${{ secrets.GCP_PROD_HOST }}
           username: ${{ secrets.GCP_USERNAME }}
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
-          envs: UPC_API_KEY,PEXELS_API_KEY,RESEND_API_KEY,EMAIL_FROM_ADDRESS,EMAIL_FROM_NAME
+          envs: UPC_API_KEY,PEXELS_API_KEY,RESEND_API_KEY,EMAIL_FROM_ADDRESS,EMAIL_FROM_NAME,CRON_SECRET
           timeout: 30s
           command_timeout: 10m
           script: |
@@ -65,6 +66,7 @@ jobs:
             RESEND_API_KEY=${RESEND_API_KEY}
             EMAIL_FROM_ADDRESS=${EMAIL_FROM_ADDRESS}
             EMAIL_FROM_NAME=${EMAIL_FROM_NAME:-Freezer Inventory}
+            CRON_SECRET=${CRON_SECRET}
             EOF
             echo "✓ Environment variables configured"
 
@@ -134,6 +136,7 @@ jobs:
             python3 migrations/run_email_verification_migration.py || echo "⚠️  Email verification migration already applied or not needed"
             python3 migrations/run_low_stock_alerts_migration.py || echo "⚠️  Low-stock migration already applied or not needed"
             python3 migrations/run_passkey_migration.py || echo "⚠️  Passkey migration already applied or not needed"
+            python3 migrations/run_expiration_notifications_migration.py || echo "⚠️  Expiration notifications migration already applied or not needed"
             # Fix ownership: migrations run as gh-deploy but gunicorn runs as michaelt452.
             # Any SQLite journal/WAL files created during migration must be owned by the
             # service user, otherwise gunicorn gets "attempt to write a readonly database".

--- a/backend/app.py
+++ b/backend/app.py
@@ -124,6 +124,7 @@ def create_app(test_config=None):
     from routes.feedback import feedback_bp
     from routes.dashboard import dashboard_bp
     from routes.notifications import notifications_bp
+    from routes.admin import admin_bp
 
     app.register_blueprint(auth_bp, url_prefix='/api/auth')
     app.register_blueprint(items_bp, url_prefix='/api/items')
@@ -134,6 +135,7 @@ def create_app(test_config=None):
     app.register_blueprint(feedback_bp, url_prefix='/api/feedback')
     app.register_blueprint(dashboard_bp, url_prefix='/api/dashboard')
     app.register_blueprint(notifications_bp, url_prefix='/api/notifications')
+    app.register_blueprint(admin_bp, url_prefix='/api/admin')
 
     # Log email configuration status so operators can confirm SMTP is wired up
     from utils.email import is_email_configured

--- a/backend/migrations/run_expiration_notifications_migration.py
+++ b/backend/migrations/run_expiration_notifications_migration.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Migration: create expiration_notification_settings table.
+
+Safe to run multiple times – skips if the table already exists.
+Supports both SQLite and PostgreSQL (via DATABASE_URL env var).
+
+Run from the backend directory:
+  python3 migrations/run_expiration_notifications_migration.py
+"""
+import os
+import sys
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv(os.path.join(os.path.dirname(__file__), '..', '.env'))
+except ImportError:
+    pass
+
+# ── Detect database type ───────────────────────────────────────────────────────
+
+database_url = os.environ.get('DATABASE_URL', '')
+
+if database_url:
+    try:
+        import psycopg2
+    except ImportError:
+        print('psycopg2 not installed; falling back to SQLAlchemy approach')
+        psycopg2 = None
+
+    if psycopg2:
+        print('Running expiration_notification_settings migration on PostgreSQL...')
+        try:
+            conn = psycopg2.connect(database_url)
+            conn.autocommit = True
+            cur = conn.cursor()
+
+            cur.execute("""
+                SELECT EXISTS (
+                    SELECT FROM information_schema.tables
+                    WHERE table_name = 'expiration_notification_settings'
+                )
+            """)
+            exists = cur.fetchone()[0]
+
+            if exists:
+                print('  expiration_notification_settings table already exists – skipping')
+            else:
+                cur.execute("""
+                    CREATE TABLE expiration_notification_settings (
+                        id SERIAL PRIMARY KEY,
+                        user_id INTEGER NOT NULL UNIQUE REFERENCES users(id),
+                        enabled BOOLEAN DEFAULT FALSE,
+                        frequency VARCHAR(10) DEFAULT 'daily',
+                        day_of_week INTEGER DEFAULT 1,
+                        days_before INTEGER DEFAULT 7,
+                        all_categories BOOLEAN DEFAULT TRUE,
+                        category_ids TEXT DEFAULT '[]',
+                        last_sent_at TIMESTAMP
+                    )
+                """)
+                print('  expiration_notification_settings table created')
+
+            cur.close()
+            conn.close()
+            print('\n✅ Migration successful!')
+        except Exception as exc:
+            print(f'❌ Migration failed: {exc}')
+            sys.exit(1)
+        sys.exit(0)
+
+# ── SQLite fallback ────────────────────────────────────────────────────────────
+
+import sqlite3
+
+_basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+_db_filename = os.environ.get('DATABASE_PATH', 'freezer_inventory.db')
+db_path = os.path.join(_basedir, 'instance', _db_filename)
+
+if not os.path.exists(db_path):
+    print(f'❌ Database not found at: {db_path}')
+    print('Run this script from the backend directory, or set DATABASE_PATH in .env.')
+    sys.exit(1)
+
+print(f'Running expiration_notification_settings migration on SQLite: {db_path}\n')
+
+conn = sqlite3.connect(db_path)
+cursor = conn.cursor()
+
+try:
+    cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='expiration_notification_settings'"
+    )
+    exists = cursor.fetchone()
+
+    if exists:
+        print('✓ expiration_notification_settings table already exists – skipping')
+    else:
+        cursor.execute("""
+            CREATE TABLE expiration_notification_settings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL UNIQUE REFERENCES users(id),
+                enabled BOOLEAN DEFAULT 0,
+                frequency VARCHAR(10) DEFAULT 'daily',
+                day_of_week INTEGER DEFAULT 1,
+                days_before INTEGER DEFAULT 7,
+                all_categories BOOLEAN DEFAULT 1,
+                category_ids TEXT DEFAULT '[]',
+                last_sent_at DATETIME
+            )
+        """)
+        conn.commit()
+        print('✓ expiration_notification_settings table created')
+
+except Exception as exc:
+    print(f'❌ Migration failed: {exc}')
+    conn.rollback()
+    conn.close()
+    sys.exit(1)
+
+conn.close()
+print('\n✅ Migration successful!')

--- a/backend/models.py
+++ b/backend/models.py
@@ -169,6 +169,34 @@ class LowStockAlert(db.Model):
         }
 
 
+class ExpirationNotificationSettings(db.Model):
+    __tablename__ = 'expiration_notification_settings'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False, unique=True)
+    enabled = db.Column(db.Boolean, default=False)
+    frequency = db.Column(db.String(10), default='daily')  # 'daily' or 'weekly'
+    day_of_week = db.Column(db.Integer, default=1)  # 0=Mon…6=Sun, used only when frequency='weekly'
+    days_before = db.Column(db.Integer, default=7)
+    all_categories = db.Column(db.Boolean, default=True)
+    category_ids = db.Column(db.Text, default='[]')  # JSON list of category IDs
+    last_sent_at = db.Column(db.DateTime)
+
+    user = db.relationship('User', backref=db.backref('expiration_settings', uselist=False))
+
+    def to_dict(self):
+        import json
+        return {
+            'enabled': bool(self.enabled),
+            'frequency': self.frequency or 'daily',
+            'day_of_week': self.day_of_week if self.day_of_week is not None else 1,
+            'days_before': self.days_before or 7,
+            'all_categories': bool(self.all_categories),
+            'category_ids': json.loads(self.category_ids or '[]'),
+            'last_sent_at': self.last_sent_at.isoformat() if self.last_sent_at else None,
+        }
+
+
 def generate_qr_code():
     """Generate a unique alphanumeric code identifier (e.g., ABC123)"""
     import random

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -1,0 +1,193 @@
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required, get_jwt
+from sqlalchemy import func
+from models import db, Item, LowStockAlert
+
+admin_bp = Blueprint('admin', __name__)
+
+
+def _require_admin():
+    claims = get_jwt()
+    if claims.get('role') != 'admin':
+        return jsonify({'error': 'Admin access required'}), 403
+    return None
+
+
+# ── Item name cleanup ─────────────────────────────────────────────────────────
+
+@admin_bp.route('/cleanup/names', methods=['GET'])
+@jwt_required()
+def list_names():
+    """List all distinct item names with active and total item counts."""
+    err = _require_admin()
+    if err:
+        return err
+
+    rows = (
+        db.session.query(Item.name, func.count(Item.id).label('total_count'))
+        .group_by(Item.name)
+        .order_by(Item.name)
+        .all()
+    )
+
+    active_counts = dict(
+        db.session.query(Item.name, func.count(Item.id))
+        .filter(Item.status == 'in_freezer')
+        .group_by(Item.name)
+        .all()
+    )
+
+    return jsonify([
+        {
+            'name': row.name,
+            'total_count': row.total_count,
+            'active_count': active_counts.get(row.name, 0),
+        }
+        for row in rows
+    ]), 200
+
+
+@admin_bp.route('/cleanup/names', methods=['PATCH'])
+@jwt_required()
+def rename_name():
+    """Rename all items from old_name to new_name (all statuses)."""
+    err = _require_admin()
+    if err:
+        return err
+
+    data = request.get_json() or {}
+    old_name = (data.get('old_name') or '').strip()
+    new_name = (data.get('new_name') or '').strip()
+
+    if not old_name or not new_name:
+        return jsonify({'error': 'old_name and new_name are required'}), 400
+    if old_name == new_name:
+        return jsonify({'error': 'New name is the same as the old name'}), 400
+
+    updated = Item.query.filter_by(name=old_name).update({'name': new_name})
+
+    # Also update any low-stock alerts referencing the old name
+    LowStockAlert.query.filter(
+        func.lower(LowStockAlert.item_name) == old_name.lower()
+    ).update({'item_name': new_name}, synchronize_session=False)
+
+    db.session.commit()
+    return jsonify({'updated_count': updated}), 200
+
+
+@admin_bp.route('/cleanup/names', methods=['DELETE'])
+@jwt_required()
+def delete_name():
+    """Permanently delete all item records with this name.
+
+    Blocked if any items with this name are currently in the freezer.
+    Also removes associated low-stock alerts.
+    """
+    err = _require_admin()
+    if err:
+        return err
+
+    data = request.get_json() or {}
+    name = (data.get('name') or '').strip()
+    if not name:
+        return jsonify({'error': 'name is required'}), 400
+
+    active_count = Item.query.filter_by(name=name, status='in_freezer').count()
+    if active_count > 0:
+        return jsonify({
+            'error': f'Cannot delete: {active_count} item(s) with this name are currently in the freezer'
+        }), 409
+
+    deleted = Item.query.filter_by(name=name).delete()
+
+    # Clean up low-stock alerts for this name
+    LowStockAlert.query.filter(
+        func.lower(LowStockAlert.item_name) == name.lower()
+    ).delete(synchronize_session=False)
+
+    db.session.commit()
+    return jsonify({'deleted_count': deleted}), 200
+
+
+# ── Source (store) cleanup ────────────────────────────────────────────────────
+
+@admin_bp.route('/cleanup/sources', methods=['GET'])
+@jwt_required()
+def list_sources():
+    """List all distinct source values with active and total item counts."""
+    err = _require_admin()
+    if err:
+        return err
+
+    rows = (
+        db.session.query(Item.source, func.count(Item.id).label('total_count'))
+        .filter(Item.source.isnot(None), Item.source != '')
+        .group_by(Item.source)
+        .order_by(Item.source)
+        .all()
+    )
+
+    active_counts = dict(
+        db.session.query(Item.source, func.count(Item.id))
+        .filter(Item.status == 'in_freezer', Item.source.isnot(None), Item.source != '')
+        .group_by(Item.source)
+        .all()
+    )
+
+    return jsonify([
+        {
+            'source': row.source,
+            'total_count': row.total_count,
+            'active_count': active_counts.get(row.source, 0),
+        }
+        for row in rows
+    ]), 200
+
+
+@admin_bp.route('/cleanup/sources', methods=['PATCH'])
+@jwt_required()
+def rename_source():
+    """Rename all items from old_source to new_source (all statuses)."""
+    err = _require_admin()
+    if err:
+        return err
+
+    data = request.get_json() or {}
+    old_source = (data.get('old_source') or '').strip()
+    new_source = (data.get('new_source') or '').strip()
+
+    if not old_source or not new_source:
+        return jsonify({'error': 'old_source and new_source are required'}), 400
+    if old_source == new_source:
+        return jsonify({'error': 'New source is the same as the old source'}), 400
+
+    updated = Item.query.filter_by(source=old_source).update({'source': new_source})
+    db.session.commit()
+    return jsonify({'updated_count': updated}), 200
+
+
+@admin_bp.route('/cleanup/sources', methods=['DELETE'])
+@jwt_required()
+def delete_source():
+    """Clear the source field from all items with this source value.
+
+    Blocked if any items with this source are currently in the freezer.
+    """
+    err = _require_admin()
+    if err:
+        return err
+
+    data = request.get_json() or {}
+    source = (data.get('source') or '').strip()
+    if not source:
+        return jsonify({'error': 'source is required'}), 400
+
+    active_count = Item.query.filter_by(source=source, status='in_freezer').count()
+    if active_count > 0:
+        return jsonify({
+            'error': f'Cannot delete: {active_count} item(s) with this store are currently in the freezer'
+        }), 409
+
+    updated = Item.query.filter_by(source=source).update({'source': None})
+    db.session.commit()
+    return jsonify({'updated_count': updated}), 200

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -23,8 +23,8 @@ def register():
     if not data or not data.get('username'):
         return jsonify({'error': 'Username required'}), 400
 
-    # Normalize username to lowercase for case-insensitive matching
-    username_lower = data['username'].lower()
+    # Normalize username to lowercase and strip whitespace
+    username_lower = data['username'].strip().lower()
 
     if User.query.filter_by(username=username_lower).first():
         return jsonify({'error': 'Username already exists'}), 400
@@ -91,8 +91,8 @@ def login():
     if not data or not data.get('username') or not data.get('password'):
         return jsonify({'error': 'Username and password required'}), 400
 
-    # Normalize username to lowercase for case-insensitive matching
-    username_lower = data['username'].lower()
+    # Normalize username to lowercase and strip whitespace
+    username_lower = data['username'].strip().lower()
 
     user = User.query.filter_by(username=username_lower).first()
 
@@ -208,8 +208,8 @@ def update_user(user_id):
 
     # Update username if provided
     if 'username' in data:
-        # Normalize username to lowercase for case-insensitive matching
-        new_username_lower = data['username'].lower()
+        # Normalize username to lowercase and strip whitespace
+        new_username_lower = data['username'].strip().lower()
 
         if new_username_lower != user.username:
             if User.query.filter_by(username=new_username_lower).first():

--- a/backend/routes/categories.py
+++ b/backend/routes/categories.py
@@ -36,12 +36,16 @@ def create_category():
     if not data or not data.get('name'):
         return jsonify({'error': 'Category name is required'}), 400
 
+    name = data['name'].strip()
+    if not name:
+        return jsonify({'error': 'Category name is required'}), 400
+
     # Check if category already exists
-    if Category.query.filter_by(name=data['name']).first():
+    if Category.query.filter_by(name=name).first():
         return jsonify({'error': 'Category already exists'}), 400
 
     category = Category(
-        name=data['name'],
+        name=name,
         default_expiration_days=data.get('default_expiration_days', 180),
         image_url=data.get('image_url'),
         created_by_user_id=current_user_id
@@ -70,14 +74,15 @@ def update_category(category_id):
     data = request.get_json()
 
     if 'name' in data:
+        new_name = data['name'].strip()
         # Check if new name already exists
         existing = Category.query.filter(
-            Category.name == data['name'],
+            Category.name == new_name,
             Category.id != category_id
         ).first()
         if existing:
             return jsonify({'error': 'Category name already exists'}), 400
-        category.name = data['name']
+        category.name = new_name
 
     if 'default_expiration_days' in data:
         category.default_expiration_days = data['default_expiration_days']

--- a/backend/routes/items.py
+++ b/backend/routes/items.py
@@ -424,6 +424,15 @@ def create_item():
 
     data['name'] = _canonical_name(data['name'])
 
+    if data.get('upc'):
+        data['upc'] = data['upc'].strip()
+
+    if data.get('source'):
+        data['source'] = data['source'].strip()
+
+    if data.get('notes'):
+        data['notes'] = data['notes'].strip()
+
     # Validate UPC format if provided (must be 12 digits)
     if data.get('upc'):
         import re
@@ -500,6 +509,7 @@ def update_item(item_id):
 
     # Validate UPC format if provided (must be 12 digits)
     if 'upc' in data and data['upc']:
+        data['upc'] = data['upc'].strip()
         import re
         if not re.match(r'^\d{12}$', data['upc']):
             return jsonify({'error': 'Invalid UPC format. UPC must be exactly 12 digits.'}), 400
@@ -512,7 +522,7 @@ def update_item(item_id):
     if 'image_url' in data:
         item.image_url = data['image_url']
     if 'source' in data:
-        item.source = data['source']
+        item.source = data['source'].strip() if data['source'] else data['source']
     if 'weight' in data:
         item.weight = data['weight']
     if 'weight_unit' in data:
@@ -524,7 +534,7 @@ def update_item(item_id):
     if 'expiration_date' in data:
         item.expiration_date = datetime.fromisoformat(data['expiration_date']) if data['expiration_date'] else None
     if 'notes' in data:
-        item.notes = data['notes']
+        item.notes = data['notes'].strip() if data['notes'] else data['notes']
     new_status = None
     if 'status' in data:
         # Validate status

--- a/backend/routes/notifications.py
+++ b/backend/routes/notifications.py
@@ -1,6 +1,6 @@
 """Notifications blueprint – email settings and test-send endpoint.
 
-Routes (all require JWT):
+Routes (all require JWT unless noted):
   GET  /api/notifications/email/status            – is email configured? (any role)
   GET  /api/notifications/email/settings          – get email settings (admin only)
   POST /api/notifications/email/test              – send a test email to own verified address (any role)
@@ -13,6 +13,10 @@ Routes (all require JWT):
   POST   /api/notifications/low-stock             – create a low-stock alert
   PUT    /api/notifications/low-stock/<id>        – update threshold / enabled
   DELETE /api/notifications/low-stock/<id>        – delete an alert
+
+  GET  /api/notifications/expiration-settings     – get current user's expiration notification prefs
+  PUT  /api/notifications/expiration-settings     – update current user's expiration notification prefs
+  POST /api/notifications/send-expiration-digest  – cron endpoint (no JWT; optional CRON_SECRET header)
 """
 
 import logging
@@ -23,8 +27,8 @@ from datetime import datetime, timedelta
 from flask import Blueprint, request, jsonify
 from flask_jwt_extended import jwt_required, get_jwt_identity, get_jwt
 from sqlalchemy import func
-from models import db, User, Item, LowStockAlert
-from utils.email import is_email_configured, send_email, send_verification_email
+from models import db, User, Item, LowStockAlert, ExpirationNotificationSettings
+from utils.email import is_email_configured, send_email, send_verification_email, send_expiration_digest
 
 notifications_bp = Blueprint('notifications', __name__)
 
@@ -416,3 +420,149 @@ def delete_low_stock_alert(alert_id):
     db.session.delete(alert)
     db.session.commit()
     return jsonify({'message': 'Alert deleted'}), 200
+
+
+# ── Expiration notification settings ──────────────────────────────────────────
+
+_EXP_DEFAULTS = {
+    'enabled': False,
+    'frequency': 'daily',
+    'day_of_week': 1,
+    'days_before': 7,
+    'all_categories': True,
+    'category_ids': [],
+    'last_sent_at': None,
+}
+
+
+@notifications_bp.route('/expiration-settings', methods=['GET'])
+@jwt_required()
+def get_expiration_settings():
+    """Return the current user's expiration notification preferences."""
+    current_user_id = int(get_jwt_identity())
+    settings = ExpirationNotificationSettings.query.filter_by(user_id=current_user_id).first()
+    if not settings:
+        return jsonify(_EXP_DEFAULTS), 200
+    return jsonify(settings.to_dict()), 200
+
+
+@notifications_bp.route('/expiration-settings', methods=['PUT'])
+@jwt_required()
+def update_expiration_settings():
+    """Create or update the current user's expiration notification preferences."""
+    import json as _json
+    current_user_id = int(get_jwt_identity())
+    data = request.get_json() or {}
+
+    settings = ExpirationNotificationSettings.query.filter_by(user_id=current_user_id).first()
+    if not settings:
+        settings = ExpirationNotificationSettings(user_id=current_user_id)
+        db.session.add(settings)
+
+    if 'enabled' in data:
+        settings.enabled = bool(data['enabled'])
+
+    if 'frequency' in data:
+        if data['frequency'] not in ('daily', 'weekly'):
+            return jsonify({'error': 'frequency must be "daily" or "weekly"'}), 400
+        settings.frequency = data['frequency']
+
+    if 'day_of_week' in data:
+        try:
+            dow = int(data['day_of_week'])
+            if not 0 <= dow <= 6:
+                raise ValueError
+            settings.day_of_week = dow
+        except (TypeError, ValueError):
+            return jsonify({'error': 'day_of_week must be 0–6'}), 400
+
+    if 'days_before' in data:
+        try:
+            days_val = int(data['days_before'])
+            if days_val < 1:
+                raise ValueError
+            settings.days_before = days_val
+        except (TypeError, ValueError):
+            return jsonify({'error': 'days_before must be a positive integer'}), 400
+
+    if 'all_categories' in data:
+        settings.all_categories = bool(data['all_categories'])
+
+    if 'category_ids' in data:
+        try:
+            ids = [int(i) for i in data['category_ids']]
+            settings.category_ids = _json.dumps(ids)
+        except (TypeError, ValueError):
+            return jsonify({'error': 'category_ids must be a list of integers'}), 400
+
+    db.session.commit()
+    return jsonify(settings.to_dict()), 200
+
+
+@notifications_bp.route('/send-expiration-digest', methods=['POST'])
+def trigger_expiration_digest():
+    """Cron endpoint – send expiration digest emails to all eligible users.
+
+    Not JWT-protected. If CRON_SECRET env var is set the caller must supply
+    the same value in the X-Cron-Secret request header.
+
+    Intended to be called once daily (e.g. via cron, systemd timer, or a
+    hosting-platform scheduler). Weekly-frequency users are skipped on days
+    that don't match their chosen day_of_week.
+    """
+    import json as _json
+
+    cron_secret = os.environ.get('CRON_SECRET', '')
+    if cron_secret and request.headers.get('X-Cron-Secret', '') != cron_secret:
+        return jsonify({'error': 'Unauthorized'}), 401
+
+    if not is_email_configured():
+        return jsonify({'error': 'Email not configured on this server'}), 503
+
+    today = datetime.utcnow()
+    results = {'sent': 0, 'skipped': 0, 'errors': 0}
+
+    all_settings = ExpirationNotificationSettings.query.filter_by(enabled=True).all()
+
+    for s in all_settings:
+        user = s.user
+        if not user or not user.email or not user.email_verified:
+            results['skipped'] += 1
+            continue
+
+        # Weekly: only send on the configured day of week
+        if s.frequency == 'weekly' and today.weekday() != s.day_of_week:
+            results['skipped'] += 1
+            continue
+
+        threshold_dt = today + timedelta(days=s.days_before)
+
+        query = Item.query.filter(
+            Item.status == 'in_freezer',
+            Item.expiration_date.isnot(None),
+            Item.expiration_date <= threshold_dt,
+        ).order_by(Item.expiration_date)
+
+        if not s.all_categories:
+            try:
+                cat_ids = _json.loads(s.category_ids or '[]')
+                if cat_ids:
+                    query = query.filter(Item.category_id.in_(cat_ids))
+            except (ValueError, TypeError):
+                pass
+
+        items = query.all()
+        if not items:
+            results['skipped'] += 1
+            continue
+
+        try:
+            send_expiration_digest(user.email, [i.to_dict() for i in items], s.days_before)
+            s.last_sent_at = datetime.utcnow()
+            db.session.commit()
+            results['sent'] += 1
+        except RuntimeError:
+            logging.exception('Failed to send expiration digest to %s', user.email)
+            results['errors'] += 1
+
+    return jsonify(results), 200

--- a/backend/utils/email.py
+++ b/backend/utils/email.py
@@ -90,6 +90,50 @@ def send_email(to_addresses, subject, text_body, html_body=None):
         logger.exception('Failed to send email to %s', ', '.join(to_addresses))
         raise RuntimeError(f'Email delivery failed: {exc}') from exc
 
+def send_expiration_digest(to_address, items, days_before):
+    """Send an expiration digest email listing items expiring soon.
+
+    Args:
+        to_address: str – recipient email address.
+        items: list of item dicts (from Item.to_dict()).
+        days_before: int – the configured threshold (used in subject/body).
+    """
+    count = len(items)
+    subject = f'Freezer expiration digest – {count} item{"s" if count != 1 else ""} expiring soon'
+
+    # Plain-text body
+    lines = [f'Freezer items expiring within {days_before} day{"s" if days_before != 1 else ""}:\n']
+    for item in items:
+        exp = item['expiration_date'][:10] if item.get('expiration_date') else 'No date'
+        cat = f' [{item["category_name"]}]' if item.get('category_name') else ''
+        lines.append(f'  \u2022 {item["name"]}{cat} \u2014 expires {exp}')
+    text_body = '\n'.join(lines) + '\n\nLog in to your Freezer Inventory to take action.'
+
+    # HTML body
+    rows = ''.join(
+        '<tr>'
+        f'<td style="padding:0.4rem 0.75rem;border-bottom:1px solid #eee">{item["name"]}</td>'
+        f'<td style="padding:0.4rem 0.75rem;border-bottom:1px solid #eee">{item.get("category_name") or "\u2014"}</td>'
+        f'<td style="padding:0.4rem 0.75rem;border-bottom:1px solid #eee">{item["expiration_date"][:10] if item.get("expiration_date") else "No date"}</td>'
+        '</tr>'
+        for item in items
+    )
+    html_body = (
+        f'<p>You have <strong>{count} item{"s" if count != 1 else ""}</strong> '
+        f'expiring within {days_before} day{"s" if days_before != 1 else ""}:</p>'
+        '<table style="border-collapse:collapse;width:100%;font-size:0.9em">'
+        '<thead><tr style="background:#f8f9fa;text-align:left">'
+        '<th style="padding:0.4rem 0.75rem">Item</th>'
+        '<th style="padding:0.4rem 0.75rem">Category</th>'
+        '<th style="padding:0.4rem 0.75rem">Expires</th>'
+        '</tr></thead>'
+        f'<tbody>{rows}</tbody></table>'
+        '<p style="margin-top:1.5rem;color:#888;font-size:0.9em">Log in to your Freezer Inventory to take action.</p>'
+    )
+
+    return send_email(to_addresses=to_address, subject=subject, text_body=text_body, html_body=html_body)
+
+
 def send_verification_email(to_address, code):
     """Send a 6-digit verification code to the given address."""
     return send_email(

--- a/backend/utils/email.py
+++ b/backend/utils/email.py
@@ -110,10 +110,11 @@ def send_expiration_digest(to_address, items, days_before):
     text_body = '\n'.join(lines) + '\n\nLog in to your Freezer Inventory to take action.'
 
     # HTML body
+    em_dash = '\u2014'
     rows = ''.join(
         '<tr>'
         f'<td style="padding:0.4rem 0.75rem;border-bottom:1px solid #eee">{item["name"]}</td>'
-        f'<td style="padding:0.4rem 0.75rem;border-bottom:1px solid #eee">{item.get("category_name") or "\u2014"}</td>'
+        f'<td style="padding:0.4rem 0.75rem;border-bottom:1px solid #eee">{item.get("category_name") or em_dash}</td>'
         f'<td style="padding:0.4rem 0.75rem;border-bottom:1px solid #eee">{item["expiration_date"][:10] if item.get("expiration_date") else "No date"}</td>'
         '</tr>'
         for item in items

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -207,7 +207,7 @@ function AppContent() {
                 <>
                   <Route path="/home" element={<MobileLanding qrEnabled={qrEnabled} />} />
                   <Route path="/" element={<Navigate to="/home" replace />} />
-                  <Route path="/inventory" element={<Inventory isMobile={true} qrEnabled={qrEnabled} />} />
+                  <Route path="/inventory" element={<Inventory isMobile={true} qrEnabled={qrEnabled} user={user} />} />
                   <Route path="/item/:qrCode" element={<QRRedirect />} />
                   <Route path="/dashboard" element={<Dashboard />} />
                   <Route path="/categories" element={<Categories />} />
@@ -219,7 +219,7 @@ function AppContent() {
               ) : (
                 // Desktop routes (unchanged)
                 <>
-                  <Route path="/" element={<Inventory qrEnabled={qrEnabled} />} />
+                  <Route path="/" element={<Inventory qrEnabled={qrEnabled} user={user} />} />
                   <Route path="/item/:qrCode" element={<QRRedirect />} />
                   <Route path="/dashboard" element={<Dashboard />} />
                   <Route path="/categories" element={<Categories />} />

--- a/frontend/src/components/AddItemModal.jsx
+++ b/frontend/src/components/AddItemModal.jsx
@@ -349,6 +349,7 @@ function AddItemModal({ item, categories, onClose, onSave, onCategoryCreated, qr
 
   const handleSubmit = async (e, keepOpen = false) => {
     e.preventDefault();
+    document.activeElement.blur();
     setError('');
 
     // Validate UPC if provided
@@ -803,6 +804,7 @@ function AddItemModal({ item, categories, onClose, onSave, onCategoryCreated, qr
                 <label htmlFor="new_category_expiration">Default Expiration Days</label>
                 <input
                   type="number"
+                  inputMode="numeric"
                   id="new_category_expiration"
                   value={newCategoryData.default_expiration_days}
                   onChange={(e) => setNewCategoryData({ ...newCategoryData, default_expiration_days: parseInt(e.target.value) })}
@@ -878,6 +880,7 @@ function AddItemModal({ item, categories, onClose, onSave, onCategoryCreated, qr
               <label htmlFor="weight">Size</label>
               <input
                 type="number"
+                inputMode="decimal"
                 id="weight"
                 name="weight"
                 value={formData.weight}

--- a/frontend/src/components/DataCleanup.jsx
+++ b/frontend/src/components/DataCleanup.jsx
@@ -156,13 +156,18 @@ function DataCleanup() {
         </div>
       )}
 
-      {/* Tabs */}
-      <div style={{ marginBottom: '-1px' }}>
-        <button style={tabStyle('names')} onClick={() => { setActiveTab('names'); setRenaming(null); setConfirmDelete(null); }}>
-          Item Names {names.length > 0 && <span style={{ color: '#6c757d', fontWeight: 'normal' }}>({names.length})</span>}
-        </button>
-        <button style={tabStyle('sources')} onClick={() => { setActiveTab('sources'); setRenaming(null); setConfirmDelete(null); }}>
-          Store Names {sources.length > 0 && <span style={{ color: '#6c757d', fontWeight: 'normal' }}>({sources.length})</span>}
+      {/* Tabs + Refresh */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: '-1px' }}>
+        <div>
+          <button style={tabStyle('names')} onClick={() => { setActiveTab('names'); setRenaming(null); setConfirmDelete(null); }}>
+            Item Names {names.length > 0 && <span style={{ color: '#6c757d', fontWeight: 'normal' }}>({names.length})</span>}
+          </button>
+          <button style={tabStyle('sources')} onClick={() => { setActiveTab('sources'); setRenaming(null); setConfirmDelete(null); }}>
+            Store Names {sources.length > 0 && <span style={{ color: '#6c757d', fontWeight: 'normal' }}>({sources.length})</span>}
+          </button>
+        </div>
+        <button style={{ ...btnStyle(), fontSize: '0.8rem', marginBottom: '2px' }} onClick={loadData} disabled={loading}>
+          {loading ? 'Loading…' : 'Refresh'}
         </button>
       </div>
 
@@ -277,11 +282,6 @@ function DataCleanup() {
         )}
       </div>
 
-      <div style={{ marginTop: '0.75rem', textAlign: 'right' }}>
-        <button style={{ ...btnStyle(), fontSize: '0.8rem' }} onClick={loadData} disabled={loading}>
-          Refresh
-        </button>
-      </div>
     </div>
   );
 }

--- a/frontend/src/components/DataCleanup.jsx
+++ b/frontend/src/components/DataCleanup.jsx
@@ -1,0 +1,289 @@
+import { useState, useEffect } from 'react';
+import api from '../services/api';
+
+/**
+ * Admin-only data cleanup panel for fixing/removing duplicate item names and
+ * store (source) values that pollute the autocomplete suggestion list.
+ *
+ * - Rename: bulk-renames a value across all item records (all statuses)
+ * - Delete: for names, permanently deletes all item records; for sources,
+ *   clears the source field. Both are blocked when active (in-freezer) items
+ *   still use the value.
+ */
+function DataCleanup() {
+  const [activeTab, setActiveTab] = useState('names');
+  const [names, setNames] = useState([]);
+  const [sources, setSources] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  // { value: string, newValue: string }
+  const [renaming, setRenaming] = useState(null);
+  // { value: string, totalCount: number, type: 'names'|'sources' }
+  const [confirmDelete, setConfirmDelete] = useState(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const loadData = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const [namesRes, sourcesRes] = await Promise.all([
+        api.get('/admin/cleanup/names'),
+        api.get('/admin/cleanup/sources'),
+      ]);
+      setNames(namesRes.data);
+      setSources(sourcesRes.data);
+    } catch {
+      setError('Failed to load cleanup data');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRenameStart = (value) => {
+    setConfirmDelete(null);
+    setRenaming({ value, newValue: value });
+    setError('');
+    setSuccess('');
+  };
+
+  const handleRenameSubmit = async (e) => {
+    e.preventDefault();
+    if (!renaming) return;
+    const trimmed = renaming.newValue.trim();
+    if (!trimmed || trimmed === renaming.value) {
+      setRenaming(null);
+      return;
+    }
+    setSaving(true);
+    setError('');
+    setSuccess('');
+    try {
+      let res;
+      if (activeTab === 'names') {
+        res = await api.patch('/admin/cleanup/names', { old_name: renaming.value, new_name: trimmed });
+        setSuccess(`Renamed to "${trimmed}" — ${res.data.updated_count} item(s) updated`);
+      } else {
+        res = await api.patch('/admin/cleanup/sources', { old_source: renaming.value, new_source: trimmed });
+        setSuccess(`Renamed to "${trimmed}" — ${res.data.updated_count} item(s) updated`);
+      }
+      setRenaming(null);
+      loadData();
+    } catch (err) {
+      setError(err.response?.data?.error || 'Rename failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!confirmDelete) return;
+    setSaving(true);
+    setError('');
+    setSuccess('');
+    try {
+      if (confirmDelete.type === 'names') {
+        const res = await api.delete('/admin/cleanup/names', { data: { name: confirmDelete.value } });
+        setSuccess(`Deleted ${res.data.deleted_count} item record(s) for "${confirmDelete.value}"`);
+      } else {
+        const res = await api.delete('/admin/cleanup/sources', { data: { source: confirmDelete.value } });
+        setSuccess(`Cleared store "${confirmDelete.value}" from ${res.data.updated_count} item(s)`);
+      }
+      setConfirmDelete(null);
+      loadData();
+    } catch (err) {
+      setError(err.response?.data?.error || 'Delete failed');
+      setConfirmDelete(null);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const rows = activeTab === 'names' ? names : sources;
+  const valueKey = activeTab === 'names' ? 'name' : 'source';
+  const colLabel = activeTab === 'names' ? 'Item Name' : 'Store Name';
+
+  const tabStyle = (tab) => ({
+    padding: '0.4rem 1rem',
+    border: '1px solid #dee2e6',
+    borderBottom: activeTab === tab ? '1px solid white' : '1px solid #dee2e6',
+    borderRadius: '4px 4px 0 0',
+    background: activeTab === tab ? 'white' : '#f8f9fa',
+    cursor: 'pointer',
+    fontWeight: activeTab === tab ? '600' : 'normal',
+    marginRight: '0.25rem',
+    fontSize: '0.9rem',
+    color: activeTab === tab ? '#212529' : '#6c757d',
+    position: 'relative',
+    bottom: '-1px',
+  });
+
+  const btnStyle = (variant = 'default') => {
+    const base = {
+      padding: '0.2rem 0.55rem',
+      borderRadius: '4px',
+      fontSize: '0.8rem',
+      cursor: 'pointer',
+      border: '1px solid',
+      lineHeight: '1.4',
+    };
+    if (variant === 'danger') return { ...base, background: '#fff5f5', borderColor: '#f5c2c7', color: '#842029' };
+    if (variant === 'primary') return { ...base, background: '#e7f1ff', borderColor: '#b6d4fe', color: '#084298' };
+    if (variant === 'success') return { ...base, background: '#d1e7dd', borderColor: '#a3cfbb', color: '#0a3622' };
+    if (variant === 'disabled') return { ...base, background: '#f8f9fa', borderColor: '#dee2e6', color: '#adb5bd', cursor: 'not-allowed' };
+    return { ...base, background: '#f8f9fa', borderColor: '#dee2e6', color: '#495057' };
+  };
+
+  return (
+    <div>
+      <p style={{ margin: '0 0 1rem', fontSize: '0.9rem', color: '#6c757d' }}>
+        View and fix duplicate or misspelled item names and store names that appear in autocomplete suggestions.
+        Rename merges all records to the new value; delete removes historical records (blocked if items are currently in the freezer).
+      </p>
+
+      {error && (
+        <div style={{ background: '#f8d7da', border: '1px solid #f5c2c7', color: '#842029', padding: '0.6rem 0.9rem', borderRadius: '4px', marginBottom: '0.75rem', fontSize: '0.875rem' }}>
+          {error}
+        </div>
+      )}
+      {success && (
+        <div style={{ background: '#d1e7dd', border: '1px solid #a3cfbb', color: '#0a3622', padding: '0.6rem 0.9rem', borderRadius: '4px', marginBottom: '0.75rem', fontSize: '0.875rem' }}>
+          {success}
+        </div>
+      )}
+
+      {/* Tabs */}
+      <div style={{ marginBottom: '-1px' }}>
+        <button style={tabStyle('names')} onClick={() => { setActiveTab('names'); setRenaming(null); setConfirmDelete(null); }}>
+          Item Names {names.length > 0 && <span style={{ color: '#6c757d', fontWeight: 'normal' }}>({names.length})</span>}
+        </button>
+        <button style={tabStyle('sources')} onClick={() => { setActiveTab('sources'); setRenaming(null); setConfirmDelete(null); }}>
+          Store Names {sources.length > 0 && <span style={{ color: '#6c757d', fontWeight: 'normal' }}>({sources.length})</span>}
+        </button>
+      </div>
+
+      {/* Table */}
+      <div style={{ border: '1px solid #dee2e6', borderRadius: '0 4px 4px 4px', overflow: 'hidden' }}>
+        {loading ? (
+          <div style={{ padding: '2rem', textAlign: 'center', color: '#6c757d' }}>Loading…</div>
+        ) : rows.length === 0 ? (
+          <div style={{ padding: '2rem', textAlign: 'center', color: '#6c757d' }}>No data found.</div>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
+            <thead>
+              <tr style={{ background: '#f8f9fa', borderBottom: '1px solid #dee2e6' }}>
+                <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: '600', color: '#495057' }}>{colLabel}</th>
+                <th style={{ padding: '0.5rem 0.75rem', textAlign: 'center', fontWeight: '600', color: '#495057', whiteSpace: 'nowrap' }}>In Freezer</th>
+                <th style={{ padding: '0.5rem 0.75rem', textAlign: 'center', fontWeight: '600', color: '#495057' }}>Total</th>
+                <th style={{ padding: '0.5rem 0.75rem', textAlign: 'right', fontWeight: '600', color: '#495057' }}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, idx) => {
+                const val = row[valueKey];
+                const isRenaming = renaming?.value === val;
+                const isConfirmingDelete = confirmDelete?.value === val;
+                const canDelete = row.active_count === 0;
+                const deleteTooltip = canDelete
+                  ? ''
+                  : `${row.active_count} item(s) currently in the freezer — rename or remove them first`;
+
+                return (
+                  <tr
+                    key={val}
+                    style={{
+                      borderBottom: idx < rows.length - 1 ? '1px solid #f0f0f0' : 'none',
+                      background: isRenaming || isConfirmingDelete ? '#f8f9fa' : 'white',
+                    }}
+                  >
+                    {/* Name/source cell — shows input when renaming */}
+                    <td style={{ padding: '0.45rem 0.75rem' }}>
+                      {isRenaming ? (
+                        <form onSubmit={handleRenameSubmit} style={{ display: 'flex', gap: '0.4rem', alignItems: 'center' }}>
+                          <input
+                            autoFocus
+                            type="text"
+                            value={renaming.newValue}
+                            onChange={(e) => setRenaming({ ...renaming, newValue: e.target.value })}
+                            style={{ flex: 1, padding: '0.2rem 0.4rem', border: '1px solid #86b7fe', borderRadius: '4px', fontSize: '0.875rem', outline: 'none' }}
+                          />
+                          <button type="submit" style={btnStyle('success')} disabled={saving}>Save</button>
+                          <button type="button" style={btnStyle()} onClick={() => setRenaming(null)}>Cancel</button>
+                        </form>
+                      ) : isConfirmingDelete ? (
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                          <span style={{ color: '#842029' }}>
+                            {activeTab === 'names'
+                              ? `Delete all ${row.total_count} record(s) for "${val}"?`
+                              : `Clear store "${val}" from ${row.total_count} record(s)?`}
+                          </span>
+                        </div>
+                      ) : (
+                        <span style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}>{val}</span>
+                      )}
+                    </td>
+
+                    <td style={{ padding: '0.45rem 0.75rem', textAlign: 'center' }}>
+                      <span style={{
+                        fontWeight: row.active_count > 0 ? '600' : 'normal',
+                        color: row.active_count > 0 ? '#0a3622' : '#6c757d',
+                      }}>
+                        {row.active_count}
+                      </span>
+                    </td>
+
+                    <td style={{ padding: '0.45rem 0.75rem', textAlign: 'center', color: '#6c757d' }}>
+                      {row.total_count}
+                    </td>
+
+                    {/* Actions cell */}
+                    <td style={{ padding: '0.45rem 0.75rem', textAlign: 'right', whiteSpace: 'nowrap' }}>
+                      {isConfirmingDelete ? (
+                        <div style={{ display: 'flex', gap: '0.4rem', justifyContent: 'flex-end' }}>
+                          <button style={btnStyle('danger')} onClick={handleDeleteConfirm} disabled={saving}>
+                            Confirm
+                          </button>
+                          <button style={btnStyle()} onClick={() => setConfirmDelete(null)}>Cancel</button>
+                        </div>
+                      ) : (
+                        <div style={{ display: 'flex', gap: '0.4rem', justifyContent: 'flex-end' }}>
+                          <button
+                            style={btnStyle('primary')}
+                            onClick={() => handleRenameStart(val)}
+                          >
+                            Rename
+                          </button>
+                          <span title={deleteTooltip}>
+                            <button
+                              style={btnStyle(canDelete ? 'danger' : 'disabled')}
+                              disabled={!canDelete}
+                              onClick={() => canDelete && setConfirmDelete({ value: val, totalCount: row.total_count, type: activeTab })}
+                            >
+                              Delete
+                            </button>
+                          </span>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div style={{ marginTop: '0.75rem', textAlign: 'right' }}>
+        <button style={{ ...btnStyle(), fontSize: '0.8rem' }} onClick={loadData} disabled={loading}>
+          Refresh
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default DataCleanup;

--- a/frontend/src/components/ItemCard.jsx
+++ b/frontend/src/components/ItemCard.jsx
@@ -2,8 +2,9 @@ import { useState } from 'react';
 import { itemsAPI } from '../services/api';
 import { formatLocalDate, daysBetween } from '../utils/dateUtils';
 
-function ItemCard({ item, onEdit, onStatusChange, qrEnabled = true }) {
+function ItemCard({ item, onEdit, onStatusChange, onDelete, isAdmin = false, qrEnabled = true }) {
   const [showQR, setShowQR] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   const getStatusClass = () => {
     return `status-badge status-${item.status}`;
@@ -151,6 +152,22 @@ function ItemCard({ item, onEdit, onStatusChange, qrEnabled = true }) {
           >
             Return to Freezer
           </button>
+        )}
+        {isAdmin && (
+          confirmDelete ? (
+            <>
+              <button className="btn btn-danger" onClick={() => { setConfirmDelete(false); onDelete(); }}>
+                Confirm Delete
+              </button>
+              <button className="btn btn-secondary" onClick={() => setConfirmDelete(false)}>
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button className="btn btn-danger" onClick={() => setConfirmDelete(true)}>
+              Delete
+            </button>
+          )
         )}
       </div>
 

--- a/frontend/src/pages/Categories.jsx
+++ b/frontend/src/pages/Categories.jsx
@@ -88,6 +88,7 @@ function Categories() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    document.activeElement.blur();
     setError('');
     setSuccess('');
     setFormError('');
@@ -235,6 +236,7 @@ function Categories() {
                   <label htmlFor="default_expiration_days">Default Expiration (days) *</label>
                   <input
                     type="number"
+                    inputMode="numeric"
                     id="default_expiration_days"
                     value={formData.default_expiration_days}
                     onChange={(e) =>

--- a/frontend/src/pages/EmailNotifications.jsx
+++ b/frontend/src/pages/EmailNotifications.jsx
@@ -331,6 +331,7 @@ function EmailNotifications() {
             </label>
             <input
               type="number"
+              inputMode="numeric"
               value={newThreshold}
               onChange={(e) => setNewThreshold(e.target.value)}
               min={1}
@@ -377,6 +378,7 @@ function EmailNotifications() {
                   <td style={tdStyle}>
                     <input
                       type="number"
+                      inputMode="numeric"
                       defaultValue={alert.threshold}
                       min={1}
                       onBlur={(e) => handleThresholdChange(alert, e.target.value)}

--- a/frontend/src/pages/EmailNotifications.jsx
+++ b/frontend/src/pages/EmailNotifications.jsx
@@ -84,16 +84,19 @@ function EmailNotifications() {
       }
 
       try {
-        const [expRes, catRes] = await Promise.all([
-          notificationsAPI.getExpirationSettings(),
-          categoriesAPI.getCategories(),
-        ]);
+        const expRes = await notificationsAPI.getExpirationSettings();
         setExpSettings(expRes.data);
-        setCategories(catRes.data || []);
       } catch (err) {
-        console.error('getExpirationSettings/categories failed:', err?.message);
+        console.error('getExpirationSettings failed:', err?.message);
       } finally {
         setExpLoading(false);
+      }
+
+      try {
+        const catRes = await categoriesAPI.getCategories();
+        setCategories(catRes.data || []);
+      } catch (err) {
+        console.error('getCategories failed:', err?.message);
       }
     };
     load();

--- a/frontend/src/pages/EmailNotifications.jsx
+++ b/frontend/src/pages/EmailNotifications.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { notificationsAPI, itemsAPI } from '../services/api';
+import { notificationsAPI, itemsAPI, categoriesAPI } from '../services/api';
 import Autocomplete from '../components/Autocomplete';
 
 function EmailNotifications() {
@@ -20,6 +20,21 @@ function EmailNotifications() {
   const [testEmailError, setTestEmailError] = useState('');
   const [testEmailSuccess, setTestEmailSuccess] = useState('');
   const [testEmailLoading, setTestEmailLoading] = useState(false);
+
+  // ── Expiration alerts state ────────────────────────────────────────────────
+  const [expSettings, setExpSettings] = useState({
+    enabled: false,
+    frequency: 'daily',
+    day_of_week: 1,
+    days_before: 7,
+    all_categories: true,
+    category_ids: [],
+  });
+  const [expLoading, setExpLoading] = useState(true);
+  const [expSaving, setExpSaving] = useState(false);
+  const [expError, setExpError] = useState('');
+  const [expSuccess, setExpSuccess] = useState('');
+  const [categories, setCategories] = useState([]);
 
   // ── Low-stock alerts state ─────────────────────────────────────────────────
   const [alerts, setAlerts] = useState([]);
@@ -66,6 +81,19 @@ function EmailNotifications() {
         setItemNameSuggestions(namesRes.data.names || []);
       } catch (err) {
         console.error('getItemNames failed:', err?.response?.status, err?.response?.data, err?.message);
+      }
+
+      try {
+        const [expRes, catRes] = await Promise.all([
+          notificationsAPI.getExpirationSettings(),
+          categoriesAPI.getCategories(),
+        ]);
+        setExpSettings(expRes.data);
+        setCategories(catRes.data || []);
+      } catch (err) {
+        console.error('getExpirationSettings/categories failed:', err?.message);
+      } finally {
+        setExpLoading(false);
       }
     };
     load();
@@ -135,6 +163,26 @@ function EmailNotifications() {
       setTestEmailError(err.response?.data?.error || 'Failed to send test email.');
     } finally {
       setTestEmailLoading(false);
+    }
+  };
+
+  // ── Expiration alert handlers ──────────────────────────────────────────────
+  const handleExpSettingChange = (key, value) => {
+    setExpSettings(prev => ({ ...prev, [key]: value }));
+  };
+
+  const handleSaveExpSettings = async () => {
+    setExpError('');
+    setExpSuccess('');
+    setExpSaving(true);
+    try {
+      const res = await notificationsAPI.updateExpirationSettings(expSettings);
+      setExpSettings(res.data);
+      setExpSuccess('Expiration alert settings saved.');
+    } catch (err) {
+      setExpError(err.response?.data?.error || 'Failed to save settings.');
+    } finally {
+      setExpSaving(false);
     }
   };
 
@@ -293,6 +341,161 @@ function EmailNotifications() {
               </small>
             )}
           </div>
+        )}
+      </section>
+
+      {/* ── Expiration alerts section ─────────────────────────────────────── */}
+      <section style={{ ...sectionStyle, marginTop: '1.5rem' }}>
+        <h3 style={sectionHeadingStyle}>Expiration alerts</h3>
+        <p style={{ margin: '0 0 1rem', fontSize: '0.875rem', color: '#7f8c8d' }}>
+          Get a digest email when items in your freezer are approaching their expiration date.
+          {!myEmailVerified && (
+            <span style={{ color: '#856404' }}> (Add a verified email above to receive alerts.)</span>
+          )}
+        </p>
+
+        {expError && <div className="error-message" style={{ marginBottom: '0.75rem' }}>{expError}</div>}
+        {expSuccess && <div className="success-message" style={{ marginBottom: '0.75rem' }}>{expSuccess}</div>}
+
+        {expLoading ? (
+          <p style={{ color: '#7f8c8d', fontSize: '0.9rem' }}>Loading…</p>
+        ) : (
+          <>
+            {/* Enable toggle */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '1.25rem' }}>
+              <input
+                type="checkbox"
+                id="exp-enabled"
+                checked={expSettings.enabled}
+                onChange={(e) => handleExpSettingChange('enabled', e.target.checked)}
+                style={{ width: '16px', height: '16px', cursor: 'pointer' }}
+              />
+              <label htmlFor="exp-enabled" style={{ cursor: 'pointer', fontWeight: '500' }}>
+                Enable expiration alerts
+              </label>
+            </div>
+
+            {expSettings.enabled && (
+              <>
+                {/* Frequency + days controls */}
+                <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', marginBottom: '1.25rem', alignItems: 'flex-end' }}>
+                  <div>
+                    <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: '#495057' }}>
+                      Frequency
+                    </label>
+                    <select
+                      value={expSettings.frequency}
+                      onChange={(e) => handleExpSettingChange('frequency', e.target.value)}
+                      style={{ padding: '0.375rem 0.75rem', border: '1px solid #ced4da', borderRadius: '4px' }}
+                    >
+                      <option value="daily">Daily</option>
+                      <option value="weekly">Weekly</option>
+                    </select>
+                  </div>
+
+                  {expSettings.frequency === 'weekly' && (
+                    <div>
+                      <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: '#495057' }}>
+                        Day of week
+                      </label>
+                      <select
+                        value={expSettings.day_of_week}
+                        onChange={(e) => handleExpSettingChange('day_of_week', parseInt(e.target.value))}
+                        style={{ padding: '0.375rem 0.75rem', border: '1px solid #ced4da', borderRadius: '4px' }}
+                      >
+                        <option value={0}>Monday</option>
+                        <option value={1}>Tuesday</option>
+                        <option value={2}>Wednesday</option>
+                        <option value={3}>Thursday</option>
+                        <option value={4}>Friday</option>
+                        <option value={5}>Saturday</option>
+                        <option value={6}>Sunday</option>
+                      </select>
+                    </div>
+                  )}
+
+                  <div>
+                    <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: '#495057' }}>
+                      Alert days before expiration
+                    </label>
+                    <input
+                      type="number"
+                      inputMode="numeric"
+                      value={expSettings.days_before}
+                      onChange={(e) => handleExpSettingChange('days_before', parseInt(e.target.value) || 1)}
+                      min={1}
+                      max={365}
+                      style={{ width: '80px', padding: '0.375rem 0.5rem', border: '1px solid #ced4da', borderRadius: '4px' }}
+                    />
+                  </div>
+                </div>
+
+                {/* Category filter */}
+                <div style={{ marginBottom: '1.25rem' }}>
+                  <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.5rem', color: '#495057', fontWeight: '500' }}>
+                    Categories to monitor
+                  </label>
+                  <div style={{ display: 'flex', gap: '1.5rem', marginBottom: '0.75rem' }}>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', cursor: 'pointer', fontSize: '0.9rem' }}>
+                      <input
+                        type="radio"
+                        name="exp-cat-filter"
+                        checked={expSettings.all_categories}
+                        onChange={() => handleExpSettingChange('all_categories', true)}
+                      />
+                      All categories
+                    </label>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', cursor: 'pointer', fontSize: '0.9rem' }}>
+                      <input
+                        type="radio"
+                        name="exp-cat-filter"
+                        checked={!expSettings.all_categories}
+                        onChange={() => handleExpSettingChange('all_categories', false)}
+                      />
+                      Specific categories
+                    </label>
+                  </div>
+
+                  {!expSettings.all_categories && (
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+                      {categories.map(cat => (
+                        <label
+                          key={cat.id}
+                          style={{
+                            display: 'flex', alignItems: 'center', gap: '0.35rem',
+                            cursor: 'pointer', fontSize: '0.875rem',
+                            background: '#f8f9fa', padding: '0.25rem 0.6rem',
+                            borderRadius: '4px', border: '1px solid #dee2e6',
+                          }}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={expSettings.category_ids.includes(cat.id)}
+                            onChange={(e) => {
+                              const ids = e.target.checked
+                                ? [...expSettings.category_ids, cat.id]
+                                : expSettings.category_ids.filter(id => id !== cat.id);
+                              handleExpSettingChange('category_ids', ids);
+                            }}
+                          />
+                          {cat.name}
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+
+            <button className="btn btn-primary" onClick={handleSaveExpSettings} disabled={expSaving || !myEmailVerified}>
+              {expSaving ? 'Saving…' : 'Save'}
+            </button>
+            {!myEmailVerified && (
+              <small style={{ color: '#856404', marginLeft: '0.75rem' }}>
+                Verify your email address above to enable this.
+              </small>
+            )}
+          </>
         )}
       </section>
 

--- a/frontend/src/pages/Inventory.jsx
+++ b/frontend/src/pages/Inventory.jsx
@@ -7,7 +7,7 @@ import QRInputModal from '../components/QRInputModal';
 import QRScanner from '../components/QRScanner';
 import SessionBanner from '../components/SessionBanner';
 
-function Inventory({ isMobile = false, qrEnabled = true }) {
+function Inventory({ isMobile = false, qrEnabled = true, user = null }) {
   const [items, setItems] = useState([]);
   const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -131,6 +131,16 @@ function Inventory({ isMobile = false, qrEnabled = true }) {
     loadItems();
     // Refresh session banner
     setSessionKey(prev => prev + 1);
+  };
+
+  const handleDeleteItem = async (itemId) => {
+    try {
+      await itemsAPI.deleteItem(itemId);
+      loadItems();
+    } catch (err) {
+      console.error('Failed to delete item:', err);
+      alert('Failed to delete item');
+    }
   };
 
   const handleStatusChange = async (itemId, newStatus) => {
@@ -415,6 +425,8 @@ function Inventory({ isMobile = false, qrEnabled = true }) {
               item={item}
               onEdit={() => handleEditItem(item)}
               onStatusChange={(status) => handleStatusChange(item.id, status)}
+              onDelete={() => handleDeleteItem(item.id)}
+              isAdmin={user?.role === 'admin'}
               qrEnabled={qrEnabled}
             />
           ))}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -4,6 +4,7 @@ import { settingsAPI, authAPI } from '../services/api';
 import UserManagement from '../components/UserManagement';
 import ImportExport from '../components/ImportExport';
 import FeedbackManagement from '../components/FeedbackManagement';
+import DataCleanup from '../components/DataCleanup';
 import api from '../services/api';
 import { isMobileDevice } from '../utils/deviceDetection';
 import { registerPasskey, supportsPasskeys, generateRecoveryCodes } from '../utils/passkey';
@@ -745,6 +746,10 @@ function Settings({ user, isMobile = false, setUseDesktopInterface }) {
 
           <SettingsSection title="User Management" badge="Admin">
             <UserManagement currentUser={user} />
+          </SettingsSection>
+
+          <SettingsSection title="Data Cleanup" badge="Admin">
+            <DataCleanup />
           </SettingsSection>
 
           <SettingsSection title="Backup & Restore" badge="Admin">

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -423,6 +423,13 @@ export const notificationsAPI = {
 
   deleteLowStockAlert: (id) =>
     api.delete(`/notifications/low-stock/${id}`),
+
+  // Expiration notification settings
+  getExpirationSettings: () =>
+    api.get('/notifications/expiration-settings'),
+
+  updateExpirationSettings: (data) =>
+    api.put('/notifications/expiration-settings', data),
 };
 
 export default api;


### PR DESCRIPTION
## Summary
- Adds a new "Expiration Alerts" section to Email Notifications settings where users can configure digest emails for items expiring within a set number of days
- Supports filtering by all categories or specific categories
- Cron-secured endpoint (`/api/notifications/send-expiration-digest`) for triggering daily digest emails

## Changes
- Backend: new expiration digest route, email template, and cron secret auth
- Frontend: Expiration Alerts UI with frequency, day-of-week, days-before, and category filtering
- Fix: f-string backslash syntax error for Python 3.10 compatibility
- Fix: categories failing to load when expiration settings fetch fails on first load