### PR TITLE
fix: allow renaming to existing names in data cleanup

### DIFF
--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -56,10 +56,10 @@ def rename_name():
         return err
 
     data = request.get_json() or {}
-    old_name = (data.get('old_name') or '').strip()
+    old_name = data.get('old_name') or ''
     new_name = (data.get('new_name') or '').strip()
 
-    if not old_name or not new_name:
+    if not old_name.strip() or not new_name:
         return jsonify({'error': 'old_name and new_name are required'}), 400
     if old_name == new_name:
         return jsonify({'error': 'New name is the same as the old name'}), 400
@@ -153,10 +153,10 @@ def rename_source():
         return err
 
     data = request.get_json() or {}
-    old_source = (data.get('old_source') or '').strip()
+    old_source = data.get('old_source') or ''
     new_source = (data.get('new_source') or '').strip()
 
-    if not old_source or not new_source:
+    if not old_source.strip() or not new_source:
         return jsonify({'error': 'old_source and new_source are required'}), 400
     if old_source == new_source:
         return jsonify({'error': 'New source is the same as the old source'}), 400


### PR DESCRIPTION
The old_name/old_source values were being stripped before the equality check and DB filter. This caused a false "same name" error when a DB entry had trailing/leading whitespace (e.g. "Beef ") and the user typed the trimmed version ("Beef") as the new name — both became "Beef" after stripping, triggering the guard incorrectly.

Now only new_name/new_source is stripped. old_name/old_source is kept as-is so the equality check and filter_by use the exact DB value, correctly allowing whitespace cleanup and merging into existing names.

https://claude.ai/code/session_01EfcWyvnSXcVvB55suVFFx2